### PR TITLE
Changed electron MVAID to from >0.0 to >0.5 in plugins/TopPairElectronPl...

### DIFF
--- a/plugins/TopPairElectronPlusJets2012SelectionFilter.cc
+++ b/plugins/TopPairElectronPlusJets2012SelectionFilter.cc
@@ -203,7 +203,7 @@ void TopPairElectronPlusJets2012SelectionFilter::getLooseElectrons() {
 bool TopPairElectronPlusJets2012SelectionFilter::isLooseElectron(const pat::Electron& electron) const {
 	bool passesPtAndEta = electron.pt() > 20 && fabs(electron.eta()) < 2.5;
 	//		bool notInCrack = fabs(electron.superCluster()->eta()) < 1.4442 || fabs(electron.superCluster()->eta()) > 1.5660;
-	bool passesID = electron.electronID("mvaTrigV0") > 0.0;
+	bool passesID = electron.electronID("mvaTrigV0") > 0.5;
 	bool passesIso = getRelativeIsolation(electron, 0.3, rho_, isRealData_, useDeltaBetaCorrections_,
 			useRhoActiveAreaCorrections_) < looseElectronIso_;
 	return passesPtAndEta && passesID && passesIso;
@@ -247,7 +247,7 @@ bool TopPairElectronPlusJets2012SelectionFilter::isGoodElectron(const pat::Elect
 	bool notInCrack = fabs(electron.superCluster()->eta()) < 1.4442 || fabs(electron.superCluster()->eta()) > 1.5660;
 	//2D impact w.r.t primary vertex
 	bool passesD0 = electron.dB(pat::Electron::PV2D) < 0.02; //cm
-	bool passesID = electron.electronID("mvaTrigV0") > 0.0;
+	bool passesID = electron.electronID("mvaTrigV0") > 0.5;
 	return passesPtAndEta && notInCrack && passesD0 && passesID;
 }
 

--- a/plugins/TopPairMuonPlusJets2012SelectionFilter.cc
+++ b/plugins/TopPairMuonPlusJets2012SelectionFilter.cc
@@ -219,7 +219,7 @@ void TopPairMuonPlusJets2012SelectionFilter::getLooseElectrons() {
 bool TopPairMuonPlusJets2012SelectionFilter::isLooseElectron(const pat::Electron& electron) const {
 	bool passesPtAndEta = electron.pt() > 20 && fabs(electron.eta()) < 2.5;
 	//		bool notInCrack = fabs(electron.superCluster()->eta()) < 1.4442 || fabs(electron.superCluster()->eta()) > 1.5660;
-	bool passesID = electron.electronID("mvaTrigV0") > 0.0;
+	bool passesID = electron.electronID("mvaTrigV0") > 0.5;
 	bool passesIso = getRelativeIsolation(electron, 0.3, rho_, isRealData_, useDeltaBetaCorrections_,
 			useRhoActiveAreaCorrections_) < looseElectronIso_;
 	return passesPtAndEta && passesID && passesIso;


### PR DESCRIPTION
...usJets2012SelectionFilter.cc and plugins/TopPairMuonPlusJets2012SelectionFilter.cc.

Tested on the data and mc sample files on soolin using unfoldingAndCutflow_cfg.py; showed small reduction in number of events in consecutiveCuts and individualCuts after the change to >0.5, as expected.
