### PR TITLE
Synchronisation of electron selection in NTupleTools with AnalysisTools....

### DIFF
--- a/plugins/TopPairElectronPlusJets2012SelectionFilter.h
+++ b/plugins/TopPairElectronPlusJets2012SelectionFilter.h
@@ -98,7 +98,7 @@ private:
 
 	//config
 	edm::InputTag jetInput_, electronInput_, muonInput_, hltInputTag_, VertexInput_, trkInput_, hcalNoiseInput_;
-	edm::InputTag hcalLaserFilterInput_, ecalDeadCellFilterInput_, trackingFailureFilter_, eeBadScFilter_;
+	edm::InputTag hcalLaserFilterInput_, ecalDeadCellFilterInput_, ecalLaserCorrFilterInput_, manystripclus53X_, toomanystripclus53X_, logErrorTooManyClusters_, trackingFailureFilter_, eeBadScFilter_;
 
 	double min1JetPt_, min2JetPt_, min3JetPt_, min4JetPt_;
 

--- a/plugins/TopPairMuonPlusJets2012SelectionFilter.cc
+++ b/plugins/TopPairMuonPlusJets2012SelectionFilter.cc
@@ -28,6 +28,10 @@ TopPairMuonPlusJets2012SelectionFilter::TopPairMuonPlusJets2012SelectionFilter(c
 		hcalNoiseInput_(iConfig.getParameter < edm::InputTag > ("HcalNoiseInput")), //
 		hcalLaserFilterInput_(iConfig.getParameter < edm::InputTag > ("HCALLaserFilterInput")), //
 		ecalDeadCellFilterInput_(iConfig.getParameter < edm::InputTag > ("ECALDeadCellFilterInput")), //
+		ecalLaserCorrFilterInput_(iConfig.getParameter < edm::InputTag > ("ECALLaserCorrFilterInput")), //
+		manystripclus53X_(iConfig.getParameter < edm::InputTag > ("ManyStripClus53XInput")), //
+		toomanystripclus53X_(iConfig.getParameter < edm::InputTag > ("TooManyStripClus53XInput")), //
+//		logErrorTooManyClusters_(iConfig.getParameter < edm::InputTag > ("LogErrorTooManyClusters")), //
 		trackingFailureFilter_(iConfig.getParameter < edm::InputTag > ("TrackingFailureFilterInput")), //
 		eeBadScFilter_(iConfig.getParameter < edm::InputTag > ("BadEESupercrystalFilterInput")), //
 		min1JetPt_(iConfig.getParameter<double>("min1JetPt")), //
@@ -84,6 +88,10 @@ void TopPairMuonPlusJets2012SelectionFilter::fillDescriptions(edm::Configuration
 	desc.add < InputTag > ("HcalNoiseInput");
 	desc.add < InputTag > ("HCALLaserFilterInput");
 	desc.add < InputTag > ("ECALDeadCellFilterInput");
+	desc.add < InputTag > ("ECALLaserCorrFilterInput");
+	desc.add < InputTag > ("ManyStripClus53XInput");
+	desc.add < InputTag > ("TooManyStripClus53XInput");
+//	desc.add < InputTag > ("LogErrorTooManyClusters");
 	desc.add < InputTag > ("TrackingFailureFilterInput");
 	desc.add < InputTag > ("BadEESupercrystalFilterInput");
 	desc.add<double>("min1JetPt", 30.0);
@@ -282,7 +290,7 @@ bool TopPairMuonPlusJets2012SelectionFilter::isGoodMuon(const pat::Muon& muon) c
 	//2D impact w.r.t primary vertex
 	if (!hasGoodPV_ or muon.globalTrack().isNull())
 		return false;
-	bool passesD0 = muon.dB(pat::Muon::PV2D) < 0.2 && fabs(muon.vertex().z() - primaryVertex_.z()) < 0.5; //cm
+	bool passesD0 = fabs(muon.dB(pat::Muon::PV2D)) < 0.2 && fabs(muon.vertex().z() - primaryVertex_.z()) < 0.5; //cm
 	bool passesID = muon.isPFMuon() && muon.isGlobalMuon();
 	bool trackQuality = muon.globalTrack()->normalizedChi2() < 10
 			&& muon.track()->hitPattern().trackerLayersWithMeasurement() > 5
@@ -396,6 +404,10 @@ bool TopPairMuonPlusJets2012SelectionFilter::passesEventCleaning(edm::Event& iEv
 		passesMETFilters = passesMETFilters && passesFilter(iEvent, hcalLaserFilterInput_);
 		passesMETFilters = passesMETFilters && passesFilter(iEvent, ecalDeadCellFilterInput_);
 		passesMETFilters = passesMETFilters && passesFilter(iEvent, trackingFailureFilter_);
+		passesMETFilters = passesMETFilters && passesFilter(iEvent, ecalLaserCorrFilterInput_);
+		passesMETFilters = passesMETFilters && !passesFilter(iEvent, manystripclus53X_);
+		passesMETFilters = passesMETFilters && !passesFilter(iEvent, toomanystripclus53X_);
+//		passesMETFilters = passesMETFilters && !passesFilter(iEvent, logErrorTooManyClusters_);
 		if (useEEBadScFilter_)
 			passesMETFilters = passesMETFilters && passesFilter(iEvent, eeBadScFilter_);
 

--- a/plugins/TopPairMuonPlusJets2012SelectionFilter.h
+++ b/plugins/TopPairMuonPlusJets2012SelectionFilter.h
@@ -94,7 +94,7 @@ private:
 
 	//config
 	edm::InputTag jetInput_, electronInput_, muonInput_, hltInputTag_, VertexInput_, trkInput_, hcalNoiseInput_;
-	edm::InputTag hcalLaserFilterInput_, ecalDeadCellFilterInput_, trackingFailureFilter_, eeBadScFilter_;
+	edm::InputTag hcalLaserFilterInput_, ecalDeadCellFilterInput_, ecalLaserCorrFilterInput_, manystripclus53X_, toomanystripclus53X_, logErrorTooManyClusters_, trackingFailureFilter_, eeBadScFilter_;
 
 	double min1JetPt_, min2JetPt_, min3JetPt_, min4JetPt_;
 

--- a/python/TopPairElectronPlusJets2012SelectionFilter_cfi.py
+++ b/python/TopPairElectronPlusJets2012SelectionFilter_cfi.py
@@ -12,9 +12,13 @@ topPairEPlusJetsSelection = cms.EDFilter('TopPairElectronPlusJets2012SelectionFi
     HcalNoiseInput=cms.InputTag('HBHENoiseFilterResultProducer', 'HBHENoiseFilterResult'),
     HCALLaserFilterInput=cms.InputTag('HcalLaserEventFilter'),
     ECALDeadCellFilterInput=cms.InputTag('EcalDeadCellTriggerPrimitiveFilter'),
- #   ECALDeadCellFilterInput=cms.InputTag('EcalDeadCellBoundaryEnergyFilter'),
     TrackingFailureFilterInput=cms.InputTag('trackingFailureFilter'),
     BadEESupercrystalFilterInput=cms.InputTag('BadEESupercrystalFilter'),
+    ECALLaserCorrFilterInput=cms.InputTag('ecalLaserCorrFilter'),
+    #trackingPOGfilters
+    ManyStripClus53XInput=cms.InputTag('manystripclus53X'),
+    TooManyStripClus53XInput=cms.InputTag('toomanystripclus53X'),
+    #LogErrorTooManyClusters=cms.InputTag('logErrorTooManyClusters'),
 
 #jet cuts
     min1JetPt=cms.double(30.),

--- a/python/TopPairMuonPlusJets2012SelectionFilter_cfi.py
+++ b/python/TopPairMuonPlusJets2012SelectionFilter_cfi.py
@@ -14,6 +14,11 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJets2012SelectionFilte
     ECALDeadCellFilterInput=cms.InputTag('EcalDeadCellTriggerPrimitiveFilter'),
     TrackingFailureFilterInput=cms.InputTag('trackingFailureFilter'),
     BadEESupercrystalFilterInput=cms.InputTag('BadEESupercrystalFilter'),
+    ECALLaserCorrFilterInput=cms.InputTag('ecalLaserCorrFilter'),
+    #trackingPOGfilters
+    ManyStripClus53XInput=cms.InputTag('manystripclus53X'),
+    TooManyStripClus53XInput=cms.InputTag('toomanystripclus53X'),
+    #LogErrorTooManyClusters=cms.InputTag('logErrorTooManyClusters'),
 
 #jet cuts
     min1JetPt=cms.double(30.),


### PR DESCRIPTION
... This is a work in progress so do not merge yet. I am making the pull request so that people can see what I have changed so far and comment on whatever is still to be corrected:
- Changed EcalDeadCellBoundaryEnergyFilter to EcalDeadCellTriggerPrimitiveFilter in python/TopPairElectronPlusJets2012SelectionFilter_cfi.py (removed discrepancy in trigger & event cleaning step). I see from Sergey's comments in Phil's pull request that some more filters and stuff need to be added here...to do.
- Changed passesd0 requirement to fabs(...) in isGoodElectron in plugins/TopPairElectronPlusJetsSelectionFilter.cc.
- Added hadronicoverEM in isGoodElectron in plugins/TopPairElectronPlusJetsSelectionFilter.cc.
- Added two separate variables in python/TopPairElectronPlusJets2012SelectionFilter_cfi.py called useDeltaBetaCorrectionsForMuons (true) and useDeltaBetaCorrectionsForElectrons (false) to use in the appropriate electron and muon functions in plugins/TopPairElectronPlusJets2012SelectionFilter.cc.
- Removed isGlobalMuon from isLooseMuon in plugins/TopPairElectronPlusJetsSelectionFilter.cc.
- Changed passesConversionVeto in plugins/TopPairElectronPlusJets2012SelectionFilter.cc to require that there is exactly one isolated electron, just like in the AnalysisTools.

There are a lot of couts which I will remove when I make the final pull request.
