### PR TITLE
Remove test files at top of config unfolding config

### DIFF
--- a/test/unfoldingAndCutflow_cfg.py
+++ b/test/unfoldingAndCutflow_cfg.py
@@ -1,20 +1,6 @@
 # import default nTuple stub
 from BristolAnalysis.NTupleTools.NTupleTools_cff import *
-##########################################################################################
-#            Test files
-##########################################################################################
-# TEST_MC_FILE = 'file:///storage/TopQuarkGroup/test/TTJets_TuneZ2_7TeV_Fall11_44X_AODSIM.root'
-# TEST_MC_FILE = 'file:///storage/TopQuarkGroup/test/TT_TuneZ2_8TeV_POWHEG_53X.root'
-TEST_MC_FILE = 'file:///storage/TopQuarkGroup/mc/8TeV/SynchEx/Summer12_DR53X_TTJets_MassiveBinDECAY_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V7A-v1.root'
 
-
-if options.isMCatNLO:
-    TEST_MC_FILE = 'file:///storage/TopQuarkGroup/test/TT_TuneZ2_8TeV_MCatNLO_53X.root'
-    # TEST_MC_FILE = 'file:///storage/TopQuarkGroup/test/TT_TuneZ2_7TeV_MCatNLO_44X.root'
-
-process.source.fileNames = [
-            TEST_MC_FILE
-            ]
 ##########################################################################################
 #            General
 ##########################################################################################


### PR DESCRIPTION
These were overwriting the input files when running interactively, regardless of the options you pass to the configuration.  It made synchronising with the ntuple workflow impossible.
