### PR TITLE
Fix bug in crab configuration for hadronisation systematic sample

### DIFF
--- a/Configuration/unfolding_Summer12/v11/TT_CT10_AUET2_8TeV-powheg-herwig_Summer12_DR53X-PU_S10_START53_V19-v1_AODSIM_nTuple_v11_NoSkim_Unfolding.cfg
+++ b/Configuration/unfolding_Summer12/v11/TT_CT10_AUET2_8TeV-powheg-herwig_Summer12_DR53X-PU_S10_START53_V19-v1_AODSIM_nTuple_v11_NoSkim_Unfolding.cfg
@@ -11,7 +11,7 @@ pset = BristolAnalysis/NTupleTools/test/unfoldingAndCutflow_cfg.py
 total_number_of_events = -1
 number_of_jobs = 2000
 get_edm_output = 1
-pycfg_params = useData=0 dataType=TTJets isTTbarMC=1 skim=NoSkim CMSSW=53X centreOfMassEnergy=8 storePDFWeights=0 applyType0METcorrection=1 applySysShiftCorrection=1
+pycfg_params = useData=0 dataType=TTJets isTTbarMC=1 skim=NoSkim CMSSW=53X centreOfMassEnergy=8 storePDFWeights=0 applyType0METcorrection=1 applySysShiftCorrection=1 isMCatNLO=1
 allow_NonProductionCMSSW = 1
 
 [USER]


### PR DESCRIPTION
The powheg-herwig sample has the same gen level structure as MC@NLO according to this random twiki:
https://twiki.cern.ch/twiki/bin/view/CMSPublic/TtbarAnaStatus2

Adding the isMCatNLO flag results in the ttbar decay analyzer being able to study the  ttbar decay.
