### PR TITLE
Updating recipe as per twiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,14 @@ export CMSSW_GIT_REFERENCE=/storage/.cmsgit-cache
 
 #change CMSSW installation paths
 export SCRAM_ARCH=slc5_amd64_gcc462
-scram p -n CMSSW_5_3_18_nTuple_v11 CMSSW_5_3_18
-cd CMSSW_5_3_18_nTuple_v11/src
+scram p -n CMSSW_5_3_20_nTuple_v11 CMSSW_5_3_20
+cd CMSSW_5_3_20_nTuple_v11/src/
 cmsenv
 
 # Latest PAT recipe
-# https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePATReleaseNotes52X#Add_new_jet_flavour
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePATReleaseNotes52X#Add_new_jet_flavour_CMSSW_5_3_20
 
 git cms-addpkg PhysicsTools/PatAlgos
-git cms-addpkg CommonTools/Utils
-git cms-addpkg PhysicsTools/Configuration
-git cms-addpkg PhysicsTools/PatExamples
-git cms-addpkg PhysicsTools/PatUtils
-git cms-addpkg PhysicsTools/SelectorUtils
-git cms-addpkg PhysicsTools/UtilAlgos
-git cms-addpkg RecoBTag/SoftLepton
-git cms-addpkg RecoMET/METFilters
-git cms-merge-topic -u cms-analysis-tools:5_3_13-newJetFlavour
-git cms-merge-topic -u cms-analysis-tools:5_3_13-updatedPATConfigs
 
 git cms-addpkg EgammaAnalysis/ElectronTools
 


### PR DESCRIPTION
New recipe for ntuple production. There are essentially no changes to the packages, it seems they've updated to CMSSW_5_3_20 and included all the packages in it, which were previously required to be checked out separately. This update is required because a lot of sites where CRAB jobs run no longer have CMSSW_5_3_18, which we were previously using.
