### PR TITLE
Updating btag weights in unfolding workflows in line with changes in BAT.

### DIFF
--- a/interface/BTagWeight.h
+++ b/interface/BTagWeight.h
@@ -10,41 +10,28 @@
 class BTagWeight {
 public:
 	BTagWeight();
-	BTagWeight(int btagSystematicFactor, int lightJetSystematicFactor);
+	BTagWeight(int btagSystematicFactor);
 
-	double weight(unsigned int numberOf_b_Jets, unsigned int numberOf_c_Jets, unsigned int numberOf_udsg_Jets,
-			double mean_bJetEfficiency, double mean_cFJetEfficiency, double mean_udsgJetEfficiency,
-			double scaleFactor_b, double scaleFactor_c, double scaleFactor_udsg, unsigned int numberOfTags) const;
-	std::vector<double> weights(const pat::JetCollection& jets, unsigned int numberOfBtags) const;
-
-	std::vector<double> weights(unsigned int numberOf_b_Jets, unsigned int numberOf_c_Jets,
-			unsigned int numberOf_udsg_Jets, double mean_bJetEfficiency, double mean_cFJetEfficiency,
-			double mean_udsgJetEfficiency, double scaleFactor_b, double scaleFactor_c, double scaleFactor_udsg,
-			unsigned int numberOfTags) const;
-
-	std::vector<double> weights(double averageScaleFactor, unsigned int numberOfTags) const;
+	double weight(const pat::JetCollection& jets, int BTagSystematic, std::string MCSampleTag ) const;
 
 	void setNumberOfBtags(unsigned int min, unsigned int max);
 
-	pat::JetCollection getBJets(const pat::JetCollection& jets) const;
-	pat::JetCollection getCJets(const pat::JetCollection& jets) const;
-	pat::JetCollection getUDSGJets(const pat::JetCollection& jets) const;
+	bool filter( unsigned int t ) const;
 
-	bool filter(unsigned int t) const;
+	double getEfficiency( const unsigned int, const pat::Jet&, std::string MCSampleTag ) const;
+	std::vector<double> getScaleFactor( const double, const pat::Jet&, std::string MCSampleTag ) const;
 
-	double getAverageBScaleFactor(const pat::JetCollection&, std::string MCSampleTag, double uncertaintyFactor = 1.) const;
-	double getBScaleFactor(const pat::Jet& jet, std::string MCSampleTag, double uncertaintyFactor = 1.) const;
-	double getAverageBEfficiency() const;
-	double getAverageCScaleFactor(const pat::JetCollection&, std::string MCSampleTag) const;
-	double getCScaleFactor(const pat::Jet&, std::string MCSampleTag) const;
-	double getAverageCEfficiency() const;
-	double getAverageUDSGScaleFactor(const pat::JetCollection&, std::string MCSampleTag) const;
-	double getUDSGScaleFactor(const pat::Jet&, std::string MCSampleTag) const;
-	double getAverageUDSGEfficiency(const pat::JetCollection&) const;
+	std::vector<double> getBScaleFactor( const pat::Jet&, std::string MCSampleTag, double uncertaintyFactor = 1. ) const;
+	double getBEfficiency( const pat::Jet&, std::string MCSampleTag ) const;
+	std::vector<double> getCScaleFactor( const pat::Jet&, std::string MCSampleTag ) const;
+	double getCEfficiency( const pat::Jet&, std::string MCSampleTag ) const;
+	std::vector<double> getUDSGScaleFactor( const pat::Jet&, std::string MCSampleTag ) const;
+	double getUDSGEfficiency( const pat::Jet&, std::string MCSampleTag ) const;
 
-	double getMeanUDSGScaleFactor(double jetPT, double jetEta, std::string MCSampleTag) const;
-	double getMinUDSGScaleFactor(double jetPT, double jetEta, std::string MCSampleTag) const;
-	double getMaxUDSGScaleFactor(double jetPT, double jetEta, std::string MCSampleTag) const;
+
+	double getMeanUDSGScaleFactor( double jetPT, double jetEta, std::string MCSampleTag ) const;
+	double getMinUDSGScaleFactor( double jetPT, double jetEta, std::string MCSampleTag ) const;
+	double getMaxUDSGScaleFactor( double jetPT, double jetEta, std::string MCSampleTag ) const;
 
 	double getMeanUDSGEfficiency(double jetPT) const;
 private:
@@ -55,6 +42,6 @@ private:
 };
 
 std::vector<double> BjetWeights(const pat::JetCollection& jets, unsigned int numberOfBtags, std::string MCSampleTag);
-std::vector<double> BjetWeights(const pat::JetCollection& jets, unsigned int numberOfBtags, int btagSystematicFactor, int lightJetSystematicFactor, std::string MCSampleTag);
+std::vector<double> BjetWeights(const pat::JetCollection& jets, unsigned int numberOfBtags, int btagSystematicFactor, std::string MCSampleTag);
 #endif
 

--- a/plugins/BTagWeight_Producer.cc
+++ b/plugins/BTagWeight_Producer.cc
@@ -13,8 +13,7 @@ BTagWeight_Producer::BTagWeight_Producer(const edm::ParameterSet& iConfig) :
 		prefix_(iConfig.getParameter < string > ("prefix")), //
 		MCSampleTag_(iConfig.getParameter < std::string > ("MCSampleTag")) , //
 		targetBtagMultiplicity_(iConfig.getParameter<unsigned int>("targetBtagMultiplicity")), //
-		BJetSystematic_(iConfig.getParameter<int>("BJetSystematic")), //
-		LightJetSystematic_(iConfig.getParameter<int>("LightJetSystematic")) {
+		BTagSystematic_(iConfig.getParameter<int>("BTagSystematic")) {
 	produces<double>();
 }
 
@@ -30,7 +29,7 @@ void BTagWeight_Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 		//get jets and numberOfBtags
 		edm::Handle < pat::JetCollection > jets;
 		iEvent.getByLabel(jetInput_, jets);
-		bjetWeights = BjetWeights(*jets, numberOfBjets, BJetSystematic_, LightJetSystematic_, MCSampleTag_);
+		bjetWeights = BjetWeights(*jets, numberOfBjets, BTagSystematic_, MCSampleTag_);
 
 		btagWeight = 0;
 		//calculate inclusive weights
@@ -51,8 +50,7 @@ void BTagWeight_Producer::fillDescriptions(edm::ConfigurationDescriptions & desc
 	desc.add < string > ("prefix", "BTagWeight_Producer");
 	desc.add < string > ("MCSampleTag");
 	desc.add<unsigned int>("targetBtagMultiplicity", 0);
-	desc.add<int>("BJetSystematic", 0);
-	desc.add<int>("LightJetSystematic", 0);
+	desc.add<int>("BTagSystematic", 0);
 
 	descriptions.add("BTagWeight_Producer", desc);
 }

--- a/plugins/BTagWeight_Producer.h
+++ b/plugins/BTagWeight_Producer.h
@@ -16,7 +16,7 @@ private:
 	const edm::InputTag numberOfTagsInput_, jetInput_;
 	const std::string prefix_, MCSampleTag_;
 	const unsigned int targetBtagMultiplicity_;//0 means >= 0, 1: >=1 etc
-	const int BJetSystematic_, LightJetSystematic_;
+	const int BTagSystematic_;
 
 };
 

--- a/python/BTagWeight_Producer_cfi.py
+++ b/python/BTagWeight_Producer_cfi.py
@@ -6,6 +6,6 @@ eventWeightBtag = cms.EDProducer("BTagWeight_Producer",
     prefix = cms.string('Weights.'),
     MCSampleTag = cms.string('Summer12'), #Fall11 or Summer12 or Summer11Leg
     targetBtagMultiplicity = cms.uint32(0),
-    BJetSystematic = cms.int32(0),
+    BTagSystematic = cms.int32(0),
 )
 

--- a/test/unfoldingAndCutflow_cfg.py
+++ b/test/unfoldingAndCutflow_cfg.py
@@ -91,7 +91,7 @@ process.eventWeightBtagEPlusJets = process.eventWeightBtag.clone(
             numberOfTagsInput = cms.InputTag( "topPairEPlusJetsSelection", electronselectionPrefix + 'NumberOfBtags', 'PAT' ),
             jetInput = cms.InputTag( "topPairEPlusJetsSelection", electronselectionPrefix + 'cleanedJets', 'PAT' ),
             targetBtagMultiplicity = cms.uint32( 2 ),  # will calculate the weight for b-tag multiplicity >=2
-            BJetSystematic = cms.int32( 0 )
+            BTagSystematic = cms.int32( 0 )
             )
 process.eventWeightBtagMuPlusJets = process.eventWeightBtagEPlusJets.clone( 
             numberOfTagsInput = cms.InputTag( "topPairMuPlusJetsSelection", muonselectionPrefix + 'NumberOfBtags', 'PAT' )  ,

--- a/test/unfoldingBLT_cfg.py
+++ b/test/unfoldingBLT_cfg.py
@@ -91,7 +91,7 @@ process.eventWeightBtagEPlusJets = process.eventWeightBtag.clone(
             numberOfTagsInput = cms.InputTag( "topPairEPlusJetsSelection", electronselectionPrefix + 'NumberOfBtags', 'PAT' ),
             jetInput = cms.InputTag( "topPairEPlusJetsSelection", electronselectionPrefix + 'cleanedJets', 'PAT' ),
             targetBtagMultiplicity = cms.uint32( 2 ),  # will calculate the weight for b-tag multiplicity >=2
-            BJetSystematic = cms.int32( 0 )
+            BTagSystematic = cms.int32( 0 )
             )
 process.eventWeightBtagMuPlusJets = process.eventWeightBtagEPlusJets.clone( 
             numberOfTagsInput = cms.InputTag( "topPairMuPlusJetsSelection", muonselectionPrefix + 'NumberOfBtags', 'PAT' )  ,


### PR DESCRIPTION
Changes have been tested, btagweight plots from the output files from running unfoldingBLT_cfg.py on TTJets datasets are below:
Previous method, 7TeV:
![original_7tev_screen shot 2014-10-02 at 09 59 50](https://cloud.githubusercontent.com/assets/2691839/4489754/4ae517c2-4a20-11e4-80be-117f205923cc.png)
New method, 7TeV:
![new_7tev_screen shot 2014-10-02 at 10 01 46](https://cloud.githubusercontent.com/assets/2691839/4489756/4f07e03c-4a20-11e4-90bd-ee0617b341fc.png)
Previous method, 8TeV:
![original_8tev_screen shot 2014-10-02 at 10 00 48](https://cloud.githubusercontent.com/assets/2691839/4489759/52780b70-4a20-11e4-85e5-b274e7d90f36.png)
New method, 8TeV:
![new_8tev_screen shot 2014-10-02 at 10 01 20](https://cloud.githubusercontent.com/assets/2691839/4489760/54060104-4a20-11e4-9e82-bf5b1054c2fe.png)

I think these follow the trends we are expecting.
