### PR TITLE
Fix application of new JEC in Ntuple tools

### DIFF
--- a/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
@@ -34,6 +34,10 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJetsSelectionFilter',
     # Minimum isolation for control region
     controlMuonIsolation=cms.double(0.3),
 
+    # Apply different JEC
+    applyJEC = cms.bool(True),
+    JetCorrectionService = cms.string('ak4PFCHSL1FastL2L3'),  
+
     # B Jet Selection
     # Working points taken from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideBTagging#Preliminary_working_or_operating
     bJetDiscriminator=cms.string('combinedInclusiveSecondaryVertexV2BJetTags'),

--- a/src/BristolNTuple_PFJets.cc
+++ b/src/BristolNTuple_PFJets.cc
@@ -204,8 +204,13 @@ void BristolNTuple_PFJets::produce(edm::Event& iEvent, const edm::EventSetup& iS
 			if (px->size() >= maxSize)
 				break;
 
+			double JEC = 1;
+			if ( readJEC ) {
+				JEC = corrector->correction( it->correctedJet("Uncorrected"), iEvent, iSetup );
+ 			}
+
 			// Only consider jets above minimum pt
-			if ( it->pt() <= minJetPtToStore )
+			if ( it->correctedJet("Uncorrected").pt() * JEC <= minJetPtToStore )
 				continue;
 
 			retpf.set(false);
@@ -222,12 +227,6 @@ void BristolNTuple_PFJets::produce(edm::Event& iEvent, const edm::EventSetup& iS
 				jecUnc->setJetEta(it->eta());
 				jecUnc->setJetPt(it->pt()); // the uncertainty is a function of the corrected pt
 			}
-
-			double JEC = 1;
-			if ( readJEC ) {
-				JEC = corrector->correction( it->correctedJet("Uncorrected"), iEvent, iSetup );
-				jec_vec->push_back(JEC);
- 			}
 
 			if (!iEvent.isRealData()) {
 				// Store generated jet resolutions for monte carlo
@@ -366,6 +365,7 @@ void BristolNTuple_PFJets::produce(edm::Event& iEvent, const edm::EventSetup& iS
 				py->push_back(it->correctedJet("Uncorrected").py() * JEC );
 				pz->push_back(it->correctedJet("Uncorrected").pz() * JEC );
 				energy->push_back(it->correctedJet("Uncorrected").energy() * JEC);
+				jec_vec->push_back(JEC);
 			}
 			else {
 				px->push_back(it->px());


### PR DESCRIPTION
Two fixes to the JEC in ntuple tools:

- The JEC were not being applied in BristolNTuple_PFJets when applying the jet pt selection
- New JEC were not being applied in the muon channel