### PR TITLE
Met corrections and filters

### DIFF
--- a/Configuration/crab3Configurations/50ns/SingleElectron_PromptReco.py
+++ b/Configuration/crab3Configurations/50ns/SingleElectron_PromptReco.py
@@ -1,0 +1,10 @@
+from BristolAnalysis.NTupleTools.commonConfig import config
+
+config.General.requestName = 'SingleElectron'
+config.JobType.pyCfgParams = ['isData=1']
+config.Data.inputDataset = '/SingleElectron/Run2015B-PromptReco-v1/MINIAOD'
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.runRange = '251643-251883'
+config.Data.unitsPerJob = 500000
+config.Data.publishDataName = 'SingleElectron'
+config.Data.lumiMask = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt'

--- a/Configuration/crab3Configurations/50ns/SingleElectron_ReReco.py
+++ b/Configuration/crab3Configurations/50ns/SingleElectron_ReReco.py
@@ -1,0 +1,9 @@
+from BristolAnalysis.NTupleTools.commonConfig import config
+
+config.General.requestName = 'SingleElectron'
+config.JobType.pyCfgParams = ['isData=1','isRereco=1']
+config.Data.inputDataset = '/SingleElectron/Run2015B-17Jul2015-v1/MINIAOD'
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.unitsPerJob = 500000
+config.Data.publishDataName = 'SingleElectron'
+config.Data.lumiMask = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt'

--- a/Configuration/crab3Configurations/50ns/SingleMuon_PromptReco.py
+++ b/Configuration/crab3Configurations/50ns/SingleMuon_PromptReco.py
@@ -1,0 +1,10 @@
+from BristolAnalysis.NTupleTools.commonConfig import config
+
+config.General.requestName = 'SingleMuon'
+config.JobType.pyCfgParams = ['isData=1']
+config.Data.inputDataset = '/SingleMuon/Run2015B-PromptReco-v1/MINIAOD'
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.runRange = '251643-251883'
+config.Data.unitsPerJob = 500000
+config.Data.publishDataName = 'SingleMuon'
+config.Data.lumiMask = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt'

--- a/Configuration/crab3Configurations/50ns/SingleMuon_ReReco.py
+++ b/Configuration/crab3Configurations/50ns/SingleMuon_ReReco.py
@@ -1,0 +1,9 @@
+from BristolAnalysis.NTupleTools.commonConfig import config
+
+config.General.requestName = 'SingleMuon'
+config.JobType.pyCfgParams = ['isData=1','isRereco=1']
+config.Data.inputDataset = '/SingleMuon/Run2015B-17Jul2015-v1/MINIAOD'
+config.Data.splitting = 'EventAwareLumiBased'
+config.Data.unitsPerJob = 500000
+config.Data.publishDataName = 'SingleMuon'
+config.Data.lumiMask = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt'

--- a/Configuration/makeTuplesFromMiniAOD_cfg.py
+++ b/Configuration/makeTuplesFromMiniAOD_cfg.py
@@ -18,6 +18,9 @@ process.source = cms.Source("PoolSource",
 #         'file:/hdfs/TopQuarkGroup/run2/miniAOD/TT_amcatnlo_25ns.root',
         'file:/hdfs/TopQuarkGroup/run2/miniAOD/TT_PowhegPythia8_50ns.root',
 #         'file:/hdfs/TopQuarkGroup/run2/miniAOD/SingleMuon.root',
+          # '/store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/244/00000/084C9A66-9227-E511-91E0-02163E0133F0.root',
+          # 'root://xrootd.unl.edu//store/data/Run2015B/SingleMuon/MINIAOD/17Jul2015-v1/30000/16B50792-172E-E511-B0C8-0025905C43EC.root',
+          # '/store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/883/00000/00CD59FD-2B2D-E511-8DB2-02163E01267F.root'
 #         '/store/data/Run2015B/SingleMuon/MINIAOD/PromptReco-v1/000/251/162/00000/160C08A3-4227-E511-B829-02163E01259F.root', #SingleMu via xrootd
 #         '/store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/096/00000/22D22D7F-5626-E511-BDE3-02163E011FAB.root',
     )
@@ -26,7 +29,7 @@ process.source = cms.Source("PoolSource",
 # If you want to run with a json file
 # import FWCore.PythonUtilities.LumiList as LumiList
 # process.source.lumisToProcess = LumiList.LumiList(filename = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251252_13TeV_PromptReco_Collisions15_JSON.txt').getVLuminosityBlockRange()
-# process.source.lumisToProcess = LumiList.LumiList(filename = '/hdfs/TopQuarkGroup/run2/json/json_DCSONLY_Run2015B.txt').getVLuminosityBlockRange()
+# process.source.lumisToProcess = LumiList.LumiList(filename = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-251883_13TeV_PromptReco_Collisions15_JSON_v2.txt').getVLuminosityBlockRange()
 
 # Use to skip events e.g. to reach a problematic event quickly
 # process.source.skipEvents = cms.untracked.uint32(4099)
@@ -53,6 +56,10 @@ setupPseudoTop( process, cms )
 from BristolAnalysis.NTupleTools.ElectronID_cff import *
 setup_electronID( process, cms )
 
+# Rerun HBHE filter
+from BristolAnalysis.NTupleTools.metFilters_cfi import *
+setupMETFilters( process, cms )
+
 # Load the selection filters and the selection analyzers
 process.load( 'BristolAnalysis.NTupleTools.muonSelection_cff')
 process.load( 'BristolAnalysis.NTupleTools.qcdMuonSelection_cff')
@@ -74,6 +81,7 @@ from BristolAnalysis.NTupleTools.NTupler_cff import *
 setup_ntupler(process, cms )
 
 process.makingNTuples = cms.Path(
+  process.HBHEFilterRerun *
   process.egmGsfElectronIDSequence *
   process.electronSelectionAnalyzerSequence *
   process.muonSelectionAnalyzerSequence *  
@@ -110,6 +118,9 @@ else :
   process.triggerSequence.remove( process.nTupleTriggerIsoMu24eta2p1MC )
   process.triggerSequence.remove( process.nTupleTriggerIsoMu20eta2p1MC )
   process.triggerSequence.remove( process.nTupleTriggerEle27WP75GsfMC )
+
+if options.isData and options.isRereco:
+  process.nTupleEvent.metFiltersInputTag = cms.InputTag('TriggerResults','','PAT')
 
 if not options.isTTbarMC:
   process.makingNTuples.remove( process.ttGenEvent )

--- a/interface/BristolNTuple_GenEventInfo.h
+++ b/interface/BristolNTuple_GenEventInfo.h
@@ -33,7 +33,7 @@ class BristolNTuple_GenEventInfo: public edm::EDProducer {
 public:
 	explicit BristolNTuple_GenEventInfo(const edm::ParameterSet&);
 private:
-	virtual void beginRun(Run const& /* iR */, EventSetup const& /* iE */)
+	virtual void beginRun(edm::Run const& /* iR */, edm::EventSetup const& /* iE */);
 
 private:
 	void initLumiWeights();

--- a/python/NTupleOptions_cff.py
+++ b/python/NTupleOptions_cff.py
@@ -26,6 +26,12 @@ def getOptions( options ):
                         VarParsing.varType.bool,
                         "Is this data")
 
+      options.register ('isRereco',
+                        False,
+                        VarParsing.multiplicity.singleton,
+                        VarParsing.varType.bool,
+                        "Is this rereco data")
+
       options.register('selectionInTaggingMode',
                         False,
                         VarParsing.multiplicity.singleton,

--- a/python/metFilters_cfi.py
+++ b/python/metFilters_cfi.py
@@ -1,0 +1,10 @@
+def setupMETFilters(process, cms):
+	process.load('CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi')
+	process.HBHENoiseFilterResultProducer.minZeros = cms.int32(99999)
+
+	process.ApplyBaselineHBHENoiseFilter = cms.EDFilter('BooleanFlagFilter',
+	   inputLabel = cms.InputTag('HBHENoiseFilterResultProducer','HBHENoiseFilterResult'),
+	   reverseDecision = cms.bool(False)
+	)
+
+	process.HBHEFilterRerun = cms.Sequence(process.HBHENoiseFilterResultProducer * process.ApplyBaselineHBHENoiseFilter)

--- a/python/submissionScripts/checkNtuple.py
+++ b/python/submissionScripts/checkNtuple.py
@@ -20,16 +20,21 @@ for crabWorkdir in os.listdir(pathOfCrabWorkdirs):
 	failedToSubmit = False
 	someJobsFailed = False
 	numberOfAttempts = 0
+	percentDone = '0'
 	while unkownOrFailed:
 		if numberOfAttempts > 0 : 'Trying again'
 		p = subprocess.Popen(['crab', 'status',pathOfCrabWorkdirs+crabWorkdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		out, err = p.communicate()
 
 		for line in out.split('\n'):
-			if line.find('finished')>=0 and line.find('100')>=0:
-				finished = True
-				unkownOrFailed = False
-				break
+			if line.find('finished')>=0 :
+				if line.find('100')>=0:
+					percentDone = '100'
+					finished = True
+					unkownOrFailed = False
+					break
+				else :
+					percentDone = line.split('finished')[-1].split('%').strip()
 			elif line.find('Task status')>=0 and line.find('FAILED')>=0:
 				failedToSubmit = True
 				break
@@ -45,13 +50,13 @@ for crabWorkdir in os.listdir(pathOfCrabWorkdirs):
 	elif failedToSubmit:
 		print crabWorkdir + ' ' + bcolors.FAIL + 'FAILED TO SUBMIT' + bcolors.ENDC #+ '...' + bcolors.OKBLUE + 'RESUBMITTING' + bcolors.ENDC
 		p = subprocess.Popen(['crab', 'status',pathOfCrabWorkdirs+crabWorkdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		out, err = p.communicate()
+		# out, err = p.communicate()
 		p = subprocess.Popen(['crab', 'resubmit',pathOfCrabWorkdirs+crabWorkdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		out, err = p.communicate() 
-		print out
+		# out, err = p.communicate() 
+		# print out
 	elif someJobsFailed:
-		print crabWorkdir + ' ' + bcolors.FAIL + 'SOME JOBS FAILED' + bcolors.ENDC #+ '...' + bcolors.OKBLUE + 'RESUBMITTING' + bcolors.ENDC
+		print crabWorkdir + ' ' + bcolors.FAIL + 'SOME JOBS FAILED' + bcolors.ENDC + '...' + bcolors.OKBLUE + percentDone + '%' + bcolors.ENDC + '...' + bcolors.OKBLUE + 'RESUBMITTING' + bcolors.ENDC
 		p = subprocess.Popen(['crab', 'resubmit',pathOfCrabWorkdirs+crabWorkdir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		out, err = p.communicate() 
-		print out
-	else: print crabWorkdir + ' ' + bcolors.WARNING + 'INCOMPLETE' + bcolors.ENDC + '\n' + out
+		# out, err = p.communicate() 
+		# print out
+	else: print crabWorkdir + ' ' + bcolors.WARNING + 'INCOMPLETE' + bcolors.ENDC + '...' + bcolors.OKBLUE + percentDone + '%' + bcolors.ENDC + '\n' + out

--- a/python/submissionScripts/submitNTuples.py
+++ b/python/submissionScripts/submitNTuples.py
@@ -10,8 +10,11 @@ print 'Using workdir ',crabWorkArea
 miniAodDir = 'BristolAnalysis/NTupleTools/Configuration/crab3Configurations/50ns/'
 jobConfigs = [
 
-miniAodDir+'SingleMuon.py',
-miniAodDir+'SingleElectron.py',
+miniAodDir+'SingleMuon_PromptReco.py',
+miniAodDir+'SingleMuon_ReReco.py',
+miniAodDir+'SingleElectron_PromptReco.py',
+miniAodDir+'SingleElectron_ReReco.py',
+
 
 # miniAodDir + 'TTJets_PowhegPythia8.py',
 

--- a/src/BristolNTuple_GenEventInfo.cc
+++ b/src/BristolNTuple_GenEventInfo.cc
@@ -369,7 +369,7 @@ void BristolNTuple_GenEventInfo::produce(edm::Event& iEvent, const edm::EventSet
 			// cout << "Number of weights : " << EvtHandle->weights().size() << endl;
 			for ( unsigned int weightIndex = 0; weightIndex < EvtHandle->weights().size(); ++weightIndex ) {
 				systematicWeights->push_back( EvtHandle->weights()[weightIndex].wgt );
-				systematicWeightIDs->push_back( EvtHandle->weights()[weightIndex].id );
+				systematicWeightIDs->push_back( atoi(EvtHandle->weights()[weightIndex].id.c_str()) );
 //				std::cout << weightIndex << " " << EvtHandle->weights()[weightIndex].id << " " << EvtHandle->weights()[weightIndex].wgt << std::endl;
 			}
 


### PR DESCRIPTION
Follow recommendations on applying MET fitlers : https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#MiniAOD

Use rereco for early runs (run<=251562), and prompt reco for later runs (run>251562), and all MET filter flags are filled correctly.  There are new crab configs for the rereco/prompt reco periods, that should only select runs without any overlap.

On top of this, the HBHE filter has to be rerun for all datasets, explained in the same link.  The code selects on these at this stage, as it's easier to do so.  Other events will be filtered out later in AT.

Fix some bugs from Luke's PR.

Add a 'percent done' printout to the checkNtuple script