### PR TITLE
Triggers

### DIFF
--- a/python/BristolNTuple_Trigger_cfi.py
+++ b/python/BristolNTuple_Trigger_cfi.py
@@ -21,16 +21,17 @@ nTupleTriggerEle23erWPLooseGsf = nTupleTrigger.clone( Prefix='HLTEle23erWPLooseG
 # Muon
 
 nTupleTriggerIsoMu18er = nTupleTrigger.clone( Prefix='HLTIsoMu18er.', PathOfInterest='HLT_IsoMu18_v', tightenTrigger = True, hltFilter = 'hltL3crIsoL1sMu16L1f0L2f10QL3f18QL3trkIsoFiltered0p09', cut = 'eta > -2.1 && eta < 2.1', minNumber = 1 )
-nTupleTriggerIsoMu20er = nTupleTrigger.clone( Prefix='HLTIsoMu20er.', PathOfInterest='HLT_IsoMu20_v')
-nTupleTriggerIsoTkMu20er = nTupleTrigger.clone( Prefix='HLTIsoTkMu20er.', PathOfInterest='HLT_IsoTkMu20_v')
+nTupleTriggerIsoMu20er = nTupleTrigger.clone( Prefix='HLTIsoMu20.', PathOfInterest='HLT_IsoMu20_v')
+nTupleTriggerIsoTkMu20er = nTupleTrigger.clone( Prefix='HLTIsoTkMu20.', PathOfInterest='HLT_IsoTkMu20_v')
 
 # MC
 nTupleTriggerEle27erWP75GsfMC = nTupleTrigger.clone( Prefix='HLTEle27erWP75GsfMC.', PathOfInterest='HLT_Ele27_eta2p1_WP75_Gsf_v')
-nTupleTriggerEle23erWP75GsfMC = nTupleTrigger.clone( Prefix='HLTEle23erWP75GsfMC.', PathOfInterest='HLT_Ele22_eta2p1_WP75_Gsf', tightenTrigger = True, hltFilter = 'hltSingleEle22WP75GsfTrackIsoFilter', cut = 'pt > 23', minNumber = 1 )
+nTupleTriggerEle23erWP75GsfMC = nTupleTrigger.clone( Prefix='HLTEle23erWP75GsfMC.', PathOfInterest='HLT_Ele22_eta2p1_WP75_Gsf_v', tightenTrigger = True, hltFilter = 'hltSingleEle22WP75GsfTrackIsoFilter', cut = 'pt > 23', minNumber = 1 )
+# nTupleTriggerEle23erWP75GsfMC = nTupleTrigger.clone( Prefix='HLTEle23erWP75GsfMC.', PathOfInterest='HLT_Ele22_eta2p1_WP75_Gsf_v' )
 
-nTupleTriggerIsoMu18erMC = nTupleTrigger.clone( Prefix='HLTIsoMu18erMC.', PathOfInterest='HLT_IsoMu17_eta2p1', tightenTrigger = True, hltFilter = 'hltL3crIsoL1sSingleMu16erL1f0L2f10QL3f17QL3trkIsoFiltered0p09', cut = 'pt > 18', minNumber = 1 )
-nTupleTriggerIsoMu20erMC = nTupleTrigger.clone( Prefix='HLTIsoMu20erMC.', PathOfInterest='HLT_IsoMu20_v')
-nTupleTriggerIsoTkMu20erMC = nTupleTrigger.clone( Prefix='HLTIsoTkMu20erMC.', PathOfInterest='HLT_IsoTkMu20_v')
+nTupleTriggerIsoMu18erMC = nTupleTrigger.clone( Prefix='HLTIsoMu18erMC.', PathOfInterest='HLT_IsoMu17_eta2p1_v', tightenTrigger = True, hltFilter = 'hltL3crIsoL1sSingleMu16erL1f0L2f10QL3f17QL3trkIsoFiltered0p09', cut = 'pt > 18', minNumber = 1 )
+nTupleTriggerIsoMu20MC = nTupleTrigger.clone( Prefix='HLTIsoMu20MC.', PathOfInterest='HLT_IsoMu20_v')
+nTupleTriggerIsoTkMu20MC = nTupleTrigger.clone( Prefix='HLTIsoTkMu20MC.', PathOfInterest='HLT_IsoTkMu20_v')
 
 
 

--- a/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
@@ -9,7 +9,7 @@ topPairEPlusJetsSelection = cms.EDFilter('TopPairElectronPlusJetsSelectionFilter
     VertexInputTag = cms.InputTag('offlineSlimmedPrimaryVertices'),
 
     # Lepton cuts
-    minSignalElectronPt=cms.double(25.),
+    minSignalElectronPt=cms.double(23.),
     maxSignalElectronEta=cms.double(2.1),
     signalElectronIDMap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium'),
     signalElectronIDMap_bitmap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-mediumBitmap'),

--- a/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
@@ -9,7 +9,7 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJetsSelectionFilter',
     VertexInput=cms.InputTag('offlineSlimmedPrimaryVertices'),
 
     # Signal muon cuts
-    minSignalMuonPt=cms.double(20.),
+    minSignalMuonPt=cms.double(18.),
     maxSignalMuonEta=cms.double(2.1),
     minLooseMuonPt=cms.double(15.),
     maxLooseMuonEta=cms.double(2.1),


### PR DESCRIPTION
- PathOfInterest

Additional triggers were being considered when looking for e.g. HLT_IsoMu17_eta2p1 and HLT_Ele22_eta2p1_WP75_Gsf.  These were being picked up:

HLT_IsoMu17_eta2p1_LooseIsoPFTau20_v1
HLT_IsoMu17_eta2p1_LooseIsoPFTau20_SingleL1_v1
HLT_IsoMu17_eta2p1_MediumIsoPFTau40_Trk1_eta2p1_Reg_v1

HLT_Ele22_eta2p1_WP75_Gsf
HLT_Ele22_eta2p1_WP75_Gsf_LooseIsoPFTau20_v1

Changed PathOfInterest to HLT_Ele22_eta2p1_WP75_Gsf_v and HLT_IsoMu17_eta2p1_v

-ER triggers

HLT_IsoMu20_v and HLT_IsoTkMu20_v are not eta restricted, so I changed the names of their output collections.  Also means you can't expect HLT_IsoMu17_eta2p1_v to pass more events than HLT_IsoMu20_v

-Offline pt cut

Also loosened the offline pt cut to be closer to the online pt cut on leptons.

