### PR TITLE
Remove b tag selection, update muon selection, total number of events

### DIFF
--- a/Configuration/makeTuplesFromMiniAOD_cfg.py
+++ b/Configuration/makeTuplesFromMiniAOD_cfg.py
@@ -205,8 +205,6 @@ if not options.isTTbarMC:
   process.selectionCriteriaAnalyzer.genSelectionCriteriaInput = cms.VInputTag()
 else:
   process.nTupleGenEventInfo.isTTbarMC = cms.bool( True )
-  process.topPairEPlusJetsSelectionTagging.bSelectionInTaggingMode = cms.bool( True )
-  process.topPairMuPlusJetsSelectionTagging.bSelectionInTaggingMode = cms.bool( True )
 
 if not options.printEventContent:
     process.makingNTuples.remove(process.printEventContent)

--- a/Configuration/makeTuplesFromMiniAOD_cfg.py
+++ b/Configuration/makeTuplesFromMiniAOD_cfg.py
@@ -45,8 +45,9 @@ process.source = cms.Source("PoolSource",
         # Prompt-Reco
         # 'root://xrootd.unl.edu//store/data/Run2015D/SingleElectron/MINIAOD/PromptReco-v4/000/258/159/00000/0EC56452-186C-E511-8158-02163E0146D5.root',
         # 'root://xrootd.unl.edu//store/data/Run2015D/SingleMuon/MINIAOD/PromptReco-v4/000/258/159/00000/6CA1C627-246C-E511-8A6A-02163E014147.root',
-        
+        # 'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/40000/00087FEB-236E-E511-9ACB-003048FF86CA.root'
         'file:/hdfs/TopQuarkGroup/run2/miniAOD/TTJets_amcanlo_25ns.root',
+        # 'file:/hdfs/TopQuarkGroup/run2/miniAOD/TTJets_powhegPythia8_25ns.root',
         # 'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/TT_TuneEE5C_13TeV-amcatnlo-herwigpp/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/10000/00A9F13F-C66D-E511-A943-0025901895CA.root'
         # 'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/60000/0005C178-4A71-E511-ACB2-0002C94CD13C.root'
     )
@@ -187,10 +188,10 @@ else :
   process.triggerSequence.remove( process.nTupleTriggerEle27erWP75GsfMC )
   process.triggerSequence.remove( process.nTupleTriggerEle23erWP75GsfMC )
   process.triggerSequence.remove( process.nTupleTriggerIsoMu18erMC )
-  process.triggerSequence.remove( process.nTupleTriggerIsoMu20erMC )
-  process.triggerSequence.remove( process.nTupleTriggerIsoTkMu20erMC )
+  process.triggerSequence.remove( process.nTupleTriggerIsoMu20MC )
+  process.triggerSequence.remove( process.nTupleTriggerIsoTkMu20MC )
   process.triggerSequence.remove( process.nTupleTrigger )
-  del process.nTupleTriggerEle27erWP75GsfMC, process.nTupleTriggerEle23erWP75GsfMC, process.nTupleTriggerIsoMu20erMC, process.nTupleTriggerIsoMu18erMC, process.nTupleTriggerIsoTkMu20erMC, process.nTupleTrigger
+  del process.nTupleTriggerEle27erWP75GsfMC, process.nTupleTriggerEle23erWP75GsfMC, process.nTupleTriggerIsoMu20MC, process.nTupleTriggerIsoMu18erMC, process.nTupleTriggerIsoTkMu20MC, process.nTupleTrigger
 
 # if options.isData and options.isRereco:
 #   process.nTupleEvent.metFiltersInputTag = cms.InputTag('TriggerResults','','PAT')

--- a/plugins/SelectionAnalyser.cc
+++ b/plugins/SelectionAnalyser.cc
@@ -14,8 +14,8 @@ SelectionAnalyser::SelectionAnalyser(const edm::ParameterSet& iConfig) :
 		selectionFlags_(iConfig.getParameter < vector<InputTag> > ("selectionFlags")), //
 		selectionNames_(iConfig.getParameter < vector<string> > ("selectionNames")), //
 		numberOfCuts_(selectionNames_.size()), //
-		// consecutiveCuts_(), //
-		// individualCuts_(), //
+		consecutiveCuts_(), //
+		individualCuts_(), //
 		consecutiveCuts_unweighted_(), //
 		individualCuts_unweighted_() {
 
@@ -36,10 +36,10 @@ void SelectionAnalyser::beginJob() {
 
 	// Histograms for PU Events
 
-	// consecutiveCuts_ = fs->make < TH1F
-	// 		> ("consecutiveCuts", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_ - 0.5);
-	// individualCuts_ = fs->make < TH1F
-	// 		> ("individualCuts", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_ - 0.5);
+	consecutiveCuts_ = fs->make < TH1F
+			> ("consecutiveCuts", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_ - 0.5);
+	individualCuts_ = fs->make < TH1F
+			> ("individualCuts", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_ - 0.5);
 	consecutiveCuts_unweighted_ = fs->make < TH1F
 			> ("consecutiveCuts_unweighted", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_
 					- 0.5);
@@ -47,15 +47,15 @@ void SelectionAnalyser::beginJob() {
 			> ("individualCuts_unweighted", "Selection cutflow; ;# Events", numberOfCuts_ , -0.5, numberOfCuts_
 					- 0.5);
 
-	// consecutiveCuts_->Sumw2();
-	// individualCuts_->Sumw2();
+	consecutiveCuts_->Sumw2();
+	individualCuts_->Sumw2();
 	consecutiveCuts_unweighted_->Sumw2();
 	individualCuts_unweighted_->Sumw2();
 
 	//setting bin names
 	for (unsigned int cut = 0; cut < numberOfCuts_; ++cut) {
-		// consecutiveCuts_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
-		// individualCuts_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
+		consecutiveCuts_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
+		individualCuts_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
 		consecutiveCuts_unweighted_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
 		individualCuts_unweighted_->GetXaxis()->SetBinLabel(cut + 1, selectionNames_.at(cut).c_str());
 	}
@@ -66,16 +66,14 @@ void SelectionAnalyser::endJob() {
 }
 
 void SelectionAnalyser::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
-	// edm::Handle<double> puWeightHandle;
-	// iEvent.getByLabel(PUWeightInput_, puWeightHandle);
 
-//	edm::Handle<double> btagWeightHandle;
-//	iEvent.getByLabel(BtagWeightInput_, btagWeightHandle);
-
-	// double puWeight(*puWeightHandle);
-//	double btagWeight(*btagWeightHandle);
-//	double weight(puWeight * btagWeight);
-	// double weight(puWeight);
+	edm::Handle < GenEventInfoProduct > genEvtInfoProduct;
+	iEvent.getByLabel("generator", genEvtInfoProduct);
+	double weight = 1;
+	if (genEvtInfoProduct.isValid()) {
+		// cout << "Gen weight : " << genEvtInfoProduct->weight() << endl;
+		weight = genEvtInfoProduct->weight() / fabs( genEvtInfoProduct->weight() );
+	}
 
 	bool passesSelectionUpTo(true);
 	for (unsigned int cut = 0; cut < numberOfCuts_; ++cut) {
@@ -83,11 +81,11 @@ void SelectionAnalyser::analyze(const edm::Event& iEvent, const edm::EventSetup&
 		bool selectionResult = passesFilter(iEvent, selectionFlags_.at(cut));
 		passesSelectionUpTo = passesSelectionUpTo && selectionResult;
 		if (selectionResult) {
-			// individualCuts_->Fill(cut, weight);
+			individualCuts_->Fill(cut, weight);
 			individualCuts_unweighted_->Fill(cut, 1.);
 		}
 		if (passesSelectionUpTo) {
-			// consecutiveCuts_->Fill(cut, weight);
+			consecutiveCuts_->Fill(cut, weight);
 			consecutiveCuts_unweighted_->Fill(cut, 1.);
 		}
 	}

--- a/plugins/SelectionAnalyser.h
+++ b/plugins/SelectionAnalyser.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "TH1F.h"
 #include "TH2F.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 class SelectionAnalyser : public edm::EDAnalyzer {
 public:
@@ -25,7 +26,7 @@ private:
 	std::vector<std::string> selectionNames_;
 	unsigned int numberOfCuts_;
 	//distributions
-	// TH1F* consecutiveCuts_, *individualCuts_;
+	TH1F* consecutiveCuts_, *individualCuts_;
 	TH1F* consecutiveCuts_unweighted_, *individualCuts_unweighted_;
 
 };

--- a/python/BristolNTuple_Trigger_cfi.py
+++ b/python/BristolNTuple_Trigger_cfi.py
@@ -47,8 +47,8 @@ triggerSequence = cms.Sequence(
     nTupleTriggerEle27erWP75GsfMC *
     nTupleTriggerEle23erWP75GsfMC *
     nTupleTriggerIsoMu18erMC *
-    nTupleTriggerIsoMu20erMC *
-    nTupleTriggerIsoTkMu20erMC 
+    nTupleTriggerIsoMu20MC *
+    nTupleTriggerIsoTkMu20MC 
 )
 
 

--- a/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
@@ -58,7 +58,7 @@ topPairEPlusJetsSelection = cms.EDFilter('TopPairElectronPlusJetsSelectionFilter
     tagAndProbeStudies = cms.bool(False),
     dropTriggerSelection = cms.bool(False),
     jetSelectionInTaggingMode = cms.bool(False),
-    bSelectionInTaggingMode = cms.bool(False),
+    bSelectionInTaggingMode = cms.bool(True),
     nonIsolatedElectronSelection = cms.bool(False),
     invertedConversionSelection = cms.bool(False),
 )

--- a/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairElectronPlusJetsSelectionFilter_cfi.py
@@ -14,8 +14,8 @@ topPairEPlusJetsSelection = cms.EDFilter('TopPairElectronPlusJetsSelectionFilter
     signalElectronIDMap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium'),
     signalElectronIDMap_bitmap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-mediumBitmap'),
     minSignalElectronID=cms.double(0),
-    minLooseMuonPt=cms.double(15.),
-    maxLooseMuonEta=cms.double(2.1),
+    minLooseMuonPt=cms.double(10.),
+    maxLooseMuonEta=cms.double(2.5),
     minLooseElectronPt=cms.double(15.),
     maxLooseElectronEta=cms.double(2.1),
     looseElectronIDMap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose'),
@@ -46,7 +46,7 @@ topPairEPlusJetsSelection = cms.EDFilter('TopPairElectronPlusJetsSelectionFilter
 
     controlElectronIsolation=cms.double(0.),
 
-    looseMuonIsolation=cms.double(0.2),
+    looseMuonIsolation=cms.double(0.25),
    
     prefix=cms.untracked.string('TopPairElectronPlusJetsSelection.'),
     MCSampleTag = cms.string('Summer12'),#Fall11 or Summer12 or Summer11Leg

--- a/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
@@ -11,8 +11,8 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJetsSelectionFilter',
     # Signal muon cuts
     minSignalMuonPt=cms.double(18.),
     maxSignalMuonEta=cms.double(2.1),
-    minLooseMuonPt=cms.double(15.),
-    maxLooseMuonEta=cms.double(2.1),
+    minLooseMuonPt=cms.double(10.),
+    maxLooseMuonEta=cms.double(2.5),
     minLooseElectronPt=cms.double(15.),
     maxLooseElectronEta=cms.double(2.1),
     looseElectronIDMap=cms.InputTag('egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose'),
@@ -30,12 +30,12 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJetsSelectionFilter',
     cleaningDeltaR=cms.double(0.4),
 
     # Maximum isolation for signal region
-    tightMuonIsolation=cms.double(0.12),
+    tightMuonIsolation=cms.double(0.15),
     # Minimum isolation for control region
     controlMuonIsolation1=cms.double(0.3),
     controlMuonIsolation2=cms.double(0.15),
 
-    looseMuonIsolation=cms.double(0.2),
+    looseMuonIsolation=cms.double(0.25),
 
     # Apply different JEC
     applyJEC = cms.bool(False),

--- a/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
+++ b/python/TopPairMuonPlusJetsSelectionFilter_cfi.py
@@ -54,7 +54,7 @@ topPairMuPlusJetsSelection = cms.EDFilter('TopPairMuonPlusJetsSelectionFilter',
 
     tagAndProbeStudies = cms.bool(False),
     dropTriggerSelection = cms.bool(False),
-    bSelectionInTaggingMode = cms.bool(False),
+    bSelectionInTaggingMode = cms.bool(True),
     nonIsolatedMuonSelection1 = cms.bool(False),
     nonIsolatedMuonSelection2 = cms.bool(False),
 )


### PR DESCRIPTION
- B Tag
Remove b tagging selection from ntuples, so we can make plots of n bjets starting from 0.
Should also make implementation of b tag efficiency measurement more clear

- Muon selection
Update muon selection for newest recommendations : https://twiki.cern.ch/twiki/bin/view/CMS/TopMUO
Muon isolation criteria from 0.12 -> 0.15
Loose muon veto, pt from 15->10, eta 2.1->2.5, isolation 0.2->0.25

- Total number of events
For e.g. amcatnlo, where there are negative gen weights, we need the total number of effective events (sum positive and negative weights) to calculate the lumi weight.