### PR TITLE
Remove b tag selection from passesOfflineSelection.

### DIFF
--- a/plugins/TopPairElectronPlusJetsSelectionFilter.cc
+++ b/plugins/TopPairElectronPlusJetsSelectionFilter.cc
@@ -97,6 +97,7 @@ TopPairElectronPlusJetsSelectionFilter::TopPairElectronPlusJetsSelectionFilter(c
 		produces<bool>(prefix_ + TTbarEPlusJetsReferenceSelection::StringSteps[step]);
 	}
 	produces<bool>(prefix_ + "FullSelection");
+	produces<bool>(prefix_ + "FullSelectionNoB");
 	produces<unsigned int>(prefix_ + "NumberOfJets");
 	produces<unsigned int>(prefix_ + "NumberOfBtags");
 	produces<std::vector<unsigned int> >(prefix_ + "cleanedJetIndex");
@@ -208,6 +209,7 @@ bool TopPairElectronPlusJetsSelectionFilter::filter(edm::Event& iEvent, const ed
 		iEvent.put(passesStep, prefix_ + TTbarEPlusJetsReferenceSelection::StringSteps[step]);
 	}
 	iEvent.put(std::auto_ptr<bool>(new bool(passesSelection)), prefix_ + "FullSelection");
+	iEvent.put(std::auto_ptr<bool>(new bool(passesSelectionExceptBtagging)), prefix_ + "FullSelectionNoB");
 
 	// Store number of cleaned jets in events
 	unsigned int numberOfJets(cleanedJets_.size());
@@ -219,7 +221,6 @@ bool TopPairElectronPlusJetsSelectionFilter::filter(edm::Event& iEvent, const ed
 	unsigned int numberOfBtags(cleanedBJets_.size());
 	iEvent.put(std::auto_ptr<unsigned int>(new unsigned int(numberOfBtags)), prefix_ + "NumberOfBtags");
 	iEvent.put(std::auto_ptr<std::vector<unsigned int> >(new std::vector<unsigned int>(cleanedBJetIndex_)), prefix_ + "cleanedBJetIndex");
-
 	iEvent.put(std::auto_ptr<unsigned int>(new unsigned int(signalElectronIndex_)),prefix_ + "signalElectronIndex");
 
 	if ( bSelectionInTaggingMode_ )

--- a/plugins/TopPairMuonPlusJetsSelectionFilter.cc
+++ b/plugins/TopPairMuonPlusJetsSelectionFilter.cc
@@ -93,6 +93,7 @@ TopPairMuonPlusJetsSelectionFilter::TopPairMuonPlusJetsSelectionFilter(const edm
 		produces<bool>(prefix_ + TTbarMuPlusJetsReferenceSelection::StringSteps[step]);
 	}
 	produces<bool>(prefix_ + "FullSelection");
+	produces<bool>(prefix_ + "FullSelectionNoB");
 	produces<unsigned int>(prefix_ + "NumberOfBtags");
 	produces<unsigned int>(prefix_ + "NumberOfJets");
 	produces<std::vector<unsigned int> >(prefix_ + "cleanedJetIndex");
@@ -201,6 +202,7 @@ bool TopPairMuonPlusJetsSelectionFilter::filter(edm::Event& iEvent, const edm::E
 		iEvent.put(passesStep, prefix_ + TTbarMuPlusJetsReferenceSelection::StringSteps[step]);
 	}
 	iEvent.put(std::auto_ptr<bool>(new bool(passesSelection)), prefix_ + "FullSelection");
+	iEvent.put(std::auto_ptr<bool>(new bool(passesSelectionExceptBtagging)), prefix_ + "FullSelectionNoB");
 
 	// Store number of cleaned jets in event
 	unsigned int numberOfJets(cleanedJets_.size());

--- a/python/SelectionCriteriaAnalyzer_cfi.py
+++ b/python/SelectionCriteriaAnalyzer_cfi.py
@@ -3,12 +3,12 @@ import FWCore.ParameterSet.Config as cms
 selectionCriteriaAnalyzer = cms.EDFilter('SelectionCriteriaAnalyzer',
     # Specify input collections
     offlineSelectionCriteriaInput      = cms.VInputTag(
-                                     cms.InputTag('topPairMuPlusJetsSelectionTagging', 'TopPairMuonPlusJetsSelection.FullSelection', 'Ntuples'),
-                                     cms.InputTag('topPairEPlusJetsSelectionTagging', 'TopPairElectronPlusJetsSelection.FullSelection', 'Ntuples'),
-                                     cms.InputTag('topPairMuPlusJetsQCDSelectionTagging2', 'TopPairMuonPlusJetsQCDSelection1p5to3.FullSelection', 'Ntuples'),
-                                     cms.InputTag('topPairMuPlusJetsQCDSelectionTagging1', 'TopPairMuonPlusJetsQCDSelection3toInf.FullSelection', 'Ntuples'),  
-                                     cms.InputTag('topPairEPlusJetsQCDSelectionTagging', 'TopPairElectronPlusJetsQCDSelection.FullSelection', 'Ntuples'),
-                                     cms.InputTag('topPairEPlusJetsConversionSelectionTagging', 'TopPairElectronPlusJetsConversionSelection.FullSelection', 'Ntuples'),
+                                     cms.InputTag('topPairMuPlusJetsSelectionTagging', 'TopPairMuonPlusJetsSelection.FullSelectionNoB', 'Ntuples'),
+                                     cms.InputTag('topPairEPlusJetsSelectionTagging', 'TopPairElectronPlusJetsSelection.FullSelectionNoB', 'Ntuples'),
+                                     cms.InputTag('topPairMuPlusJetsQCDSelectionTagging2', 'TopPairMuonPlusJetsQCDSelection1p5to3.FullSelectionNoB', 'Ntuples'),
+                                     cms.InputTag('topPairMuPlusJetsQCDSelectionTagging1', 'TopPairMuonPlusJetsQCDSelection3toInf.FullSelectionNoB', 'Ntuples'),  
+                                     cms.InputTag('topPairEPlusJetsQCDSelectionTagging', 'TopPairElectronPlusJetsQCDSelection.FullSelectionNoB', 'Ntuples'),
+                                     cms.InputTag('topPairEPlusJetsConversionSelectionTagging', 'TopPairElectronPlusJetsConversionSelection.FullSelectionNoB', 'Ntuples'),
             ),
     genSelectionCriteriaInput      = cms.VInputTag(
 									# cms.InputTag('ttFullHadronicFilter',       	 '', 'Ntuples'),


### PR DESCRIPTION
Even though b tagging selection was in tagging mode, the decision on whether an event was output to the ntuple was taken on the full selection criteria.

In the meantime, there is enough info in the ntuples to work around this, but this should go in for the next set of ntuples.