### PR TITLE
Cmssw 8 0 x no console

### DIFF
--- a/interface/BristolNTuple_PFJets.h
+++ b/interface/BristolNTuple_PFJets.h
@@ -1,6 +1,7 @@
 #ifndef BristolNTuplePFJetsExtra
 #define BristolNTuplePFJetsExtra
 
+#include <string>
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -27,6 +28,7 @@ class BristolNTuple_PFJets : public edm::EDProducer {
   const edm::EDGetTokenT<std::vector<reco::Vertex>> vtxInputTag;
   const bool isRealData;
 
+  const std::string btagCalibrationFile_;
   BTagCalibration calib;
   BTagCalibrationReader reader_bc;
   BTagCalibrationReader reader_bc_up;

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
 	],
 	"project_page": "https://github.com/BristolTopGroup",
 	"license": "Apache License, Version 2.0",
-	"cmssw_version": "CMSSW_7_6_3_patch2",
+	"cmssw_version": "CMSSW_8_0_7_patch2",
 	"dependencies": [{
 			"name": "TopSkimming",
 			"source": "https://github.com/BristolTopGroup/TopSkimming.git",

--- a/python/BristolNTuple_PFJets_cfi.py
+++ b/python/BristolNTuple_PFJets_cfi.py
@@ -12,5 +12,8 @@ nTuplePFJets = cms.EDProducer("BristolNTuple_PFJets",
     JetCorrectionService = cms.string('ak4PFCHSL1FastL2L3'),    
     DoVertexAssociation = cms.bool(True),
     VertexInputTag = cms.InputTag('offlineSlimmedPrimaryVertices'),
-    isRealData = cms.bool(False)
+    isRealData = cms.bool(False),
+    btagCalibrationFile = cms.string('CSVv2.csv'),
+#     btagCalibrationFile = cms.string)'BristolAnalysis/NTupleTools/data/BTagSF/CSVv2.csv'),
+#     btagCalibrationFile = cms.string('/vagrant/data/BTagSF/CSVv2.csv'),
 )

--- a/python/Jets_Setup_cff.py
+++ b/python/Jets_Setup_cff.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.PFJetParameters_cfi import *
 from RecoJets.JetProducers.CaloJetParameters_cfi import *
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 from RecoJets.JetProducers.GenJetParameters_cfi import *
-
+from BristolAnalysis.NTupleTools.NTupleOptions_cff import CMSSW_MAJOR_VERSION, CMSSW_MINOR_VERSION
 # this has to run AFTER setup_PF2PAT
 
 
@@ -76,13 +76,19 @@ def setup_jets(process, cms, options, postfix="PFlow"):
     print 'PF Jets'
     print inputJetCorrLabel
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
+    if int(CMSSW_MAJOR_VERSION) < 8:
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetCorrFactorsUpdated as updatedPatJetCorrFactors
+    else:
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
     process.patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
       src = cms.InputTag("slimmedJets"),
       levels = inputJetCorrLabel[1],
       payload = inputJetCorrLabel[0] ) # Make sure to choose the appropriate levels and payload here!
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
+    if int(CMSSW_MAJOR_VERSION) < 8:
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetsUpdated as updatedPatJets
+    else:
+        from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
     process.patJetsReapplyJEC = updatedPatJets.clone(
       jetSource = cms.InputTag("slimmedJets"),
       jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"))

--- a/python/Jets_Setup_cff.py
+++ b/python/Jets_Setup_cff.py
@@ -76,73 +76,16 @@ def setup_jets(process, cms, options, postfix="PFlow"):
     print 'PF Jets'
     print inputJetCorrLabel
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetCorrFactorsUpdated
-    process.patJetCorrFactorsReapplyJEC = patJetCorrFactorsUpdated.clone(
+    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors
+    process.patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
       src = cms.InputTag("slimmedJets"),
       levels = inputJetCorrLabel[1],
       payload = inputJetCorrLabel[0] ) # Make sure to choose the appropriate levels and payload here!
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import patJetsUpdated
-    process.patJetsReapplyJEC = patJetsUpdated.clone(
+    from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
+    process.patJetsReapplyJEC = updatedPatJets.clone(
       jetSource = cms.InputTag("slimmedJets"),
       jetCorrFactorsSource = cms.VInputTag(cms.InputTag("patJetCorrFactorsReapplyJEC"))
       )
 
     process.reapplyJEC = cms.Sequence( process.patJetCorrFactorsReapplyJEC + process.patJetsReapplyJEC )
-
-#     if options.CMSSW == '44X':
-#         process.patJetCorrFactorsPFlow.payload = inputJetCorrLabel[0]
-#         process.patJetCorrFactorsPFlow.levels = inputJetCorrLabel[1]
-#         process.patJetCorrFactorsPFlow.rho = cms.InputTag("kt6PFJets", "rho")
-#
-#     ###############################
-#     #### Jet RECO includes ########
-#     ###############################
-#
-#     from RecoJets.JetProducers.SubJetParameters_cfi import SubJetParameters
-#
-#     ###############################
-#     ###### Bare KT 0.6 jets #######
-#     ###############################
-#
-#     from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
-#
-#     process.kt6PFJets = kt4PFJets.clone(
-#                                         rParam=cms.double(0.6),
-#                                         doAreaFastjet=cms.bool(True),
-#                                         doRhoFastjet=cms.bool(True)
-#     )
-#     process.kt6PFJetsPFlow = kt4PFJets.clone(
-#                                              rParam=cms.double(0.6),
-#                                              src=cms.InputTag('pfNoElectron' + postfix),
-#                                              doAreaFastjet=cms.bool(True),
-#                                              doRhoFastjet=cms.bool(True)
-#     )
-#     process.kt4PFJetsPFlow = kt4PFJets.clone(
-#                                              rParam=cms.double(0.4),
-#                                              src=cms.InputTag('pfNoElectron' + postfix),
-#                                              doAreaFastjet=cms.bool(True),
-#                                              doRhoFastjet=cms.bool(True)
-#     )
-#
-#     ###############################
-#     ### TagInfo and Matching Setup#
-#     ###############################
-#
-# Do some configuration of the jet substructure things
-#     for jetcoll in [process.patJetsPFlow] :
-#         if options.useData == False :
-#             jetcoll.embedGenJetMatch = True
-#             jetcoll.getJetMCFlavour = True
-#             jetcoll.addGenPartonMatch = True
-# Add CATopTag info... piggy-backing on b-tag functionality
-#         jetcoll.addBTagInfo = True
-#         jetcoll.embedCaloTowers = True
-#         jetcoll.embedPFCandidates = True
-#
-#     additionalJets = [getattr(process, "kt6PFJets"),
-#                       getattr(process, "kt6PFJets" + postfix),
-#                       getattr(process, "kt4PFJets" + postfix)]
-#     pfNoElectron = getattr(process, "pfNoElectron" + postfix)
-#     for module in additionalJets :
-#         getattr(process, "patPF2PATSequence" + postfix).replace(pfNoElectron, pfNoElectron * module)

--- a/python/NTupleOptions_cff.py
+++ b/python/NTupleOptions_cff.py
@@ -1,5 +1,6 @@
 from FWCore.ParameterSet.VarParsing import VarParsing
 import sys
+import os
 
 def getOptions( options ):
       options.register ('tagAndProbe',
@@ -70,3 +71,6 @@ def getOptions( options ):
             print 'Error : Do not run tag and probe studies without jet selection in tagging mode.'
             sys.exit()
 
+CMSSW_VERSION = os.environ['CMSSW_VERSION']
+varray = CMSSW_VERSION.split('_')
+CMSSW_MAJOR_VERSION, CMSSW_MINOR_VERSION = varray[1], varray[2]

--- a/src/BristolNTuple_PFJets.cc
+++ b/src/BristolNTuple_PFJets.cc
@@ -26,9 +26,8 @@ BristolNTuple_PFJets::BristolNTuple_PFJets(const edm::ParameterSet& iConfig) :
 		doVertexAssociation(iConfig.getParameter<bool>("DoVertexAssociation")), //
 		vtxInputTag(consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("VertexInputTag"))), //		
 		isRealData(iConfig.getParameter<bool>("isRealData")),
-
-		// calib("csvv2", "BristolAnalysis/NTupleTools/data/BTagSF/CSVv2.csv"),
-		calib("csvv2", "CSVv2.csv"),
+		btagCalibrationFile_(iConfig.getParameter<std::string>("btagCalibrationFile")), //
+		calib("csvv2", btagCalibrationFile_.c_str()), //
 		reader_bc(		&calib,               // calibration instance
 					BTagEntry::OP_MEDIUM,  // operating point
 					"mujets",               // measurement type


### PR DESCRIPTION
Changes for 80X (#199). We should tag a version before merging.
Effectively you can still read 76X data and simulation in 80X it would be interesting to know if we can do that without problems.

Next are the triggers.