### PR TITLE
[MRG] A new take on selections - part 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+Feel free to contribute
+==================
+
+# Structure of the project
+ - bin: includes scripts, part of PATH
+ - condor: deprecated
+ - data: directory for JSON and ROOT files that are allowed to be public
+ - external: directory for external projects
+ - interface: directory for header files (`*.h`)
+ - notes: directory to place notes of all kinds
+ - plugins: directory for header (`*.h`) and source files (`*.cc`) that need to
+   			be exported as plugins, i.e. used in the Python config files.
+ - python: directory for all python files, part of PYTHONPATH
+ - src: directory for source files (`*.cc`)
+ - vagrant: directory for additional files for vagrant
+ - BuildFile.xml: build configuration for CMSSW
+ 
+# Before you begin
+ 1. Create a fork of https://github.com/BristolTopGroup/NTupleProduction/
+ 2. clone your fork
+ 3. create a branch with a name that describes the work you want to do
+ 4. develop your code
+ 5. push the changes into your for
+ 6. create a new pull request: https://github.com/BristolTopGroup/NTupleProduction/pulls
+   
+ 

--- a/notes/selections.md
+++ b/notes/selections.md
@@ -53,6 +53,10 @@ https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePythonTips
 
 
 Filtering with JSON: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideGoodLumiSectionsJSONFile#filterJSON_py
+1) curl https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ to get available JSONs
+2) regex for JSONs and 'last modified'
+3) pick latest JSON.txt
+
 
 import FWCore.PythonUtilities.LumiList as LumiList
 process.source.lumisToProcess = LumiList.LumiList(filename = 'goodList.json').getVLuminosityBlockRange()

--- a/python/ntp/commands/create/cutflow/__init__.py
+++ b/python/ntp/commands/create/cutflow/__init__.py
@@ -162,9 +162,9 @@ class Command(C):
                 }
             }
         '''
-        run_number = 1
-        lumi_section = 2
-        event_number = 3
+        run_number = getattr(event, 'Event.Run')
+        lumi_section = getattr(event, 'Event.LumiSection')
+        event_number = getattr(event, 'Event.Number')
         passing = getattr(event, branch)
         if not passing:
             return

--- a/python/ntp/commands/create/cutflow/__init__.py
+++ b/python/ntp/commands/create/cutflow/__init__.py
@@ -1,26 +1,27 @@
 """
     cutflow:
         Lists the cut-flow for a given ntuple file. Can produce either a
-        summary (default) or a detailed list of events.
+        summary (default) or a detailed list of events passing each cut in
+        JSON format. The JSON files can be later used for filtering.
         
     Usage:
         cutflow ntuple.root [format=table,JSON]
         
     Parameters:
-        format: The format of the output. Default: table
+        format: The format of the output. Format=table will print a table on
+                the screen while format=JSON will create two JSON files in 
+                workspace/results with detailed information about which event
+                passed which cut.
+                Default: format=table
 """
-from __future__ import division
 import logging
 import os
 from .. import Command as C
-from ntp.commands.setup import RESULTDIR
+from ntp.commands.setup import CMSSW_SRC
+from ntp.interpreter import time_function
 
 LOG = logging.getLogger(__name__)
-
-MUON_CHANNEL = 'topPairMuPlusJetsSelectionAnalyser/consecutiveCuts'
-ELECTRON_CHANNEL = 'topPairEPlusJetsSelectionAnalyser/consecutiveCuts'
-
-# TODO load CMSSW into PYTHONPATH
+CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 
 
 class Command(C):
@@ -32,149 +33,63 @@ class Command(C):
     def __init__(self, path=__file__, doc=__doc__):
         super(Command, self).__init__(path, doc)
 
+    @time_function('create cutflow', LOG)
     def run(self, args, variables):
         self.__prepare(args, variables)
         input_file = args[0]
         LOG.debug('Reading {0}'.format(input_file))
 
         output_format = self.__variables['format']
+        commands = [
+            'cd {CMSSW_SRC}',
+            'source /cvmfs/cms.cern.ch/cmsset_default.sh',
+            'eval `/cvmfs/cms.cern.ch/common/scram runtime -sh`',
+            'python {CURRENT_FOLDER}/{script}.py {input_file}',
+        ]
+        script = 'create_table'
         if output_format.lower() == 'table':
-            self.__create_table(input_file)
+            script = 'create_table'
         elif output_format.lower() == 'json':
-            self.__create_full_json(input_file)
+            script = 'create_json'
         else:
             self.__text = 'Unknown format "{0}"'.format(output_format)
             return False
+
+        all_in_one = ' && '.join(commands)
+        all_in_one = all_in_one.format(
+            CMSSW_SRC=CMSSW_SRC,
+            CURRENT_FOLDER=CURRENT_FOLDER,
+            input_file=input_file,
+            script=script,
+        )
+
+        from ntp.interpreter import call
+        code, stdout, stderr = call(
+            [all_in_one], LOG, stdout_log_level=logging.DEBUG, shell=True)
+
+        if not code == 0:
+            LOG.error('An error occured: ' + stdout + stderr)
+            return False
+        
+        self.__text = ''
+        if output_format == 'table':
+            import json
+            output = self.__clean_stdout(stdout)
+            text = json.loads(output)
+            self.__text = '\n'.join(text)
+        else:
+            text = stdout
         return True
-
-    def __create_table(self, input_file):
-        from ROOT import TFile
-        f = TFile.Open(input_file)
-        mu_hist = f.Get(MUON_CHANNEL)
-        e_hist = f.Get(ELECTRON_CHANNEL)
-
-        mu_cutflow = self.__extract_numbers_and_labels(mu_hist)
-        e_cutflow = self.__extract_numbers_and_labels(e_hist)
-
-        f.Close()
-
-        self.__text = "Cutflow for muon channel:\n"
-        self.__format_cutflow(mu_cutflow)
-        self.__text += "\nCutflow for electron channel:\n"
-        self.__format_cutflow(e_cutflow)
-
-    def __extract_numbers_and_labels(self, histogram):
-        n_bins = histogram.GetNbinsX()
-        cutflow = []
-        for i in range(1, n_bins + 1):
-            name = histogram.GetXaxis().GetBinLabel(i)
-            value = int(histogram.GetBinContent(i))
-            cutflow.append((name, value))
-        return cutflow
-
-    def __format_cutflow(self, cutflow):
-        headers = ['Step #', 'Step name', '# events', 'eff', 'total eff']
-        max_len_name = max([len(name) for (name, _) in cutflow])
-        # add some space
-        row_format = "{:<3}\t"
-        row_format += "{:<" + str(max_len_name) + "}\t"
-        row_format += "{:<10}\t"
-        row_format += "{:<3}%\t"
-        row_format += "{:<3}%\n"
-
-        self.__text += row_format.format(*headers)
-        self.__text += '-' * (30 + max_len_name)
-        self.__text += '\n'
-
-        for i, c in enumerate(cutflow):
-            name, value = c
-            total_efficiency = round(value / cutflow[0][1] * 100., 2)
-            efficiency = 100.
-            if i > 0:
-                efficiency = round(value / cutflow[i - 1][1] * 100., 2)
-            outputs = [i, name, value, efficiency, total_efficiency]
-            self.__text += row_format.format(*outputs)
-
-    def __create_full_json(self, input_file):
-        from ROOT import TFile
-        e_prefix = 'TopPairElectronPlusJetsSelection'
-        mu_prefix = 'TopPairMuonPlusJetsSelection'
-        e_steps = [
-            'AllEvents',
-            'EventCleaningAndTrigger',
-            'ExactlyOneSignalElectron',
-            'LooseMuonVeto',
-            'LooseElectronVeto',
-            'ConversionVeto',
-            'AtLeastOneGoodJet',
-            'AtLeastTwoGoodJets',
-            'AtLeastThreeGoodJets',
-            'AtLeastFourGoodJets',
-            'AtLeastOneBtag',
-            'AtLeastTwoBtags',
-        ]
-        mu_steps = [
-            'AllEvents',
-            'EventCleaningAndTrigger',
-            'ExactlyOneSignalMuon',
-            'LooseMuonVeto',
-            'LooseElectronVeto',
-            'AtLeastOneGoodJet',
-            'AtLeastTwoGoodJets',
-            'AtLeastThreeGoodJets',
-            'AtLeastFourGoodJets',
-            'AtLeastOneBtag',
-            'AtLeastTwoBtags',
-        ]
-        e_branches = [e_prefix + '.' + step for step in e_steps]
-        mu_branches = [mu_prefix + '.' + step for step in mu_steps]
-        f = TFile.Open(input_file)
-        tree = f.Get('nTupleTree/tree')
-        e_cutflow = {step:{} for step in e_steps}
-        mu_cutflow = {step:{} for step in mu_steps}
-
-        for event in tree:
-            for step, branch in zip(e_steps, e_branches):
-                self.__fill_cutflow(
-                    e_cutflow[step], event, step, branch)
-            for step, branch in zip(mu_steps, mu_branches):
-                self.__fill_cutflow(
-                    mu_cutflow[step], event, step, branch)
-        f.Close()
-
-        import json
-        e_output = os.path.join(RESULTDIR, 'e_cutflow.json')
-        mu_output = os.path.join(RESULTDIR, 'mu_cutflow.json')
-        with open(e_output, 'w+') as f:
-            f.write(json.dumps(e_cutflow))
-        with open(mu_output, 'w+') as f:
-            f.write(json.dumps(mu_cutflow))
-
-    def __fill_cutflow(self, cutflow, event, step, branch):
-        '''
-            A cutflow dictionary sho8uld be of the form
-            {
-                "name": "name of step",
-                "passing": {
-                    run_number:{
-                        lumi_section: [event_number, ...]
-                    }
-                }
-            }
-        '''
-        run_number = getattr(event, 'Event.Run')
-        lumi_section = getattr(event, 'Event.LumiSection')
-        event_number = getattr(event, 'Event.Number')
-        passing = getattr(event, branch)
-        if not passing:
-            return
-
-        if not "passing" in cutflow:
-            cutflow["passing"] = {}
-
-        if not run_number in cutflow["passing"]:
-            cutflow["passing"][run_number] = {}
-
-        if not lumi_section in cutflow["passing"][run_number]:
-            cutflow["passing"][run_number][lumi_section] = []
-        cutflow["passing"][run_number][lumi_section].append(event_number)
+    
+    def __clean_stdout(self, stdout):
+        import re
+        regex = '(\[")(.*?)("\])'
+        m = re.search(regex, stdout)
+        result = stdout
+        if m:
+            # 1st group == ["
+            # 2nd group json
+            # 3rd group == "]
+            result =  m.group(1) + m.group(2) +  m.group(3)
+            return result
+        return result

--- a/python/ntp/commands/create/cutflow/__init__.py
+++ b/python/ntp/commands/create/cutflow/__init__.py
@@ -1,0 +1,180 @@
+"""
+    cutflow:
+        Lists the cut-flow for a given ntuple file. Can produce either a
+        summary (default) or a detailed list of events.
+        
+    Usage:
+        cutflow ntuple.root [format=table,JSON]
+        
+    Parameters:
+        format: The format of the output. Default: table
+"""
+from __future__ import division
+import logging
+import os
+from .. import Command as C
+from ntp.commands.setup import RESULTDIR
+
+LOG = logging.getLogger(__name__)
+
+MUON_CHANNEL = 'topPairMuPlusJetsSelectionAnalyser/consecutiveCuts'
+ELECTRON_CHANNEL = 'topPairEPlusJetsSelectionAnalyser/consecutiveCuts'
+
+# TODO load CMSSW into PYTHONPATH
+
+
+class Command(C):
+
+    DEFAULTS = {
+        'format': 'table',
+    }
+
+    def __init__(self, path=__file__, doc=__doc__):
+        super(Command, self).__init__(path, doc)
+
+    def run(self, args, variables):
+        self.__prepare(args, variables)
+        input_file = args[0]
+        LOG.debug('Reading {0}'.format(input_file))
+
+        output_format = self.__variables['format']
+        if output_format.lower() == 'table':
+            self.__create_table(input_file)
+        elif output_format.lower() == 'json':
+            self.__create_full_json(input_file)
+        else:
+            self.__text = 'Unknown format "{0}"'.format(output_format)
+            return False
+        return True
+
+    def __create_table(self, input_file):
+        from ROOT import TFile
+        f = TFile.Open(input_file)
+        mu_hist = f.Get(MUON_CHANNEL)
+        e_hist = f.Get(ELECTRON_CHANNEL)
+
+        mu_cutflow = self.__extract_numbers_and_labels(mu_hist)
+        e_cutflow = self.__extract_numbers_and_labels(e_hist)
+
+        f.Close()
+
+        self.__text = "Cutflow for muon channel:\n"
+        self.__format_cutflow(mu_cutflow)
+        self.__text += "\nCutflow for electron channel:\n"
+        self.__format_cutflow(e_cutflow)
+
+    def __extract_numbers_and_labels(self, histogram):
+        n_bins = histogram.GetNbinsX()
+        cutflow = []
+        for i in range(1, n_bins + 1):
+            name = histogram.GetXaxis().GetBinLabel(i)
+            value = int(histogram.GetBinContent(i))
+            cutflow.append((name, value))
+        return cutflow
+
+    def __format_cutflow(self, cutflow):
+        headers = ['Step #', 'Step name', '# events', 'eff', 'total eff']
+        max_len_name = max([len(name) for (name, _) in cutflow])
+        # add some space
+        row_format = "{:<3}\t"
+        row_format += "{:<" + str(max_len_name) + "}\t"
+        row_format += "{:<10}\t"
+        row_format += "{:<3}%\t"
+        row_format += "{:<3}%\n"
+
+        self.__text += row_format.format(*headers)
+        self.__text += '-' * (30 + max_len_name)
+        self.__text += '\n'
+
+        for i, c in enumerate(cutflow):
+            name, value = c
+            total_efficiency = round(value / cutflow[0][1] * 100., 2)
+            efficiency = 100.
+            if i > 0:
+                efficiency = round(value / cutflow[i - 1][1] * 100., 2)
+            outputs = [i, name, value, efficiency, total_efficiency]
+            self.__text += row_format.format(*outputs)
+
+    def __create_full_json(self, input_file):
+        from ROOT import TFile
+        e_prefix = 'TopPairElectronPlusJetsSelection'
+        mu_prefix = 'TopPairMuonPlusJetsSelection'
+        e_steps = [
+            'AllEvents',
+            'EventCleaningAndTrigger',
+            'ExactlyOneSignalElectron',
+            'LooseMuonVeto',
+            'LooseElectronVeto',
+            'ConversionVeto',
+            'AtLeastOneGoodJet',
+            'AtLeastTwoGoodJets',
+            'AtLeastThreeGoodJets',
+            'AtLeastFourGoodJets',
+            'AtLeastOneBtag',
+            'AtLeastTwoBtags',
+        ]
+        mu_steps = [
+            'AllEvents',
+            'EventCleaningAndTrigger',
+            'ExactlyOneSignalMuon',
+            'LooseMuonVeto',
+            'LooseElectronVeto',
+            'AtLeastOneGoodJet',
+            'AtLeastTwoGoodJets',
+            'AtLeastThreeGoodJets',
+            'AtLeastFourGoodJets',
+            'AtLeastOneBtag',
+            'AtLeastTwoBtags',
+        ]
+        e_branches = [e_prefix + '.' + step for step in e_steps]
+        mu_branches = [mu_prefix + '.' + step for step in mu_steps]
+        f = TFile.Open(input_file)
+        tree = f.Get('nTupleTree/tree')
+        e_cutflow = {step:{} for step in e_steps}
+        mu_cutflow = {step:{} for step in mu_steps}
+
+        for event in tree:
+            for step, branch in zip(e_steps, e_branches):
+                self.__fill_cutflow(
+                    e_cutflow[step], event, step, branch)
+            for step, branch in zip(mu_steps, mu_branches):
+                self.__fill_cutflow(
+                    mu_cutflow[step], event, step, branch)
+        f.Close()
+
+        import json
+        e_output = os.path.join(RESULTDIR, 'e_cutflow.json')
+        mu_output = os.path.join(RESULTDIR, 'mu_cutflow.json')
+        with open(e_output, 'w+') as f:
+            f.write(json.dumps(e_cutflow))
+        with open(mu_output, 'w+') as f:
+            f.write(json.dumps(mu_cutflow))
+
+    def __fill_cutflow(self, cutflow, event, step, branch):
+        '''
+            A cutflow dictionary sho8uld be of the form
+            {
+                "name": "name of step",
+                "passing": {
+                    run_number:{
+                        lumi_section: [event_number, ...]
+                    }
+                }
+            }
+        '''
+        run_number = 1
+        lumi_section = 2
+        event_number = 3
+        passing = getattr(event, branch)
+        if not passing:
+            return
+
+        if not "passing" in cutflow:
+            cutflow["passing"] = {}
+
+        if not run_number in cutflow["passing"]:
+            cutflow["passing"][run_number] = {}
+
+        if not lumi_section in cutflow["passing"][run_number]:
+            cutflow["passing"][run_number][lumi_section] = []
+        cutflow["passing"][run_number][lumi_section].append(event_number)

--- a/python/ntp/commands/create/cutflow/create_json.py
+++ b/python/ntp/commands/create/cutflow/create_json.py
@@ -1,0 +1,121 @@
+import logging
+import sys
+import ntp
+LOG = logging.getLogger('ntp.commands.create.cutflow')
+
+TREE_PATH = 'nTupleTree/tree'
+E_PREFIX = 'TopPairElectronPlusJetsSelection'
+MU_PREFIX = 'TopPairMuonPlusJetsSelection'
+E_STEPS = [
+    'AllEvents',
+    'EventCleaningAndTrigger',
+    'ExactlyOneSignalElectron',
+    'LooseMuonVeto',
+    'LooseElectronVeto',
+    'ConversionVeto',
+    'AtLeastOneGoodJet',
+    'AtLeastTwoGoodJets',
+    'AtLeastThreeGoodJets',
+    'AtLeastFourGoodJets',
+    'AtLeastOneBtag',
+    'AtLeastTwoBtags',
+]
+MU_STEPS = [
+    'AllEvents',
+    'EventCleaningAndTrigger',
+    'ExactlyOneSignalMuon',
+    'LooseMuonVeto',
+    'LooseElectronVeto',
+    'AtLeastOneGoodJet',
+    'AtLeastTwoGoodJets',
+    'AtLeastThreeGoodJets',
+    'AtLeastFourGoodJets',
+    'AtLeastOneBtag',
+    'AtLeastTwoBtags',
+]
+
+
+def fill_cutflow(cutflow, event, step, branch):
+    '''
+        A cutflow dictionary sho8uld be of the form
+        {
+            "name of step": {
+                "passing": {
+                    run_number:{
+                        lumi_section: [event_number, ...]
+                    }
+                }
+            }
+        }
+    '''
+    run_number = getattr(event, 'Event.Run')
+    lumi_section = getattr(event, 'Event.LumiSection')
+    event_number = getattr(event, 'Event.Number')
+    passing = getattr(event, branch)
+    if not passing:
+        return
+
+    if not "passing" in cutflow:
+        cutflow["passing"] = {}
+
+    if not run_number in cutflow["passing"]:
+        cutflow["passing"][run_number] = {}
+
+    if not lumi_section in cutflow["passing"][run_number]:
+        cutflow["passing"][run_number][lumi_section] = []
+
+    cutflow["passing"][run_number][lumi_section].append(event_number)
+
+
+def read_cutflows(input_file):
+    from ROOT import TFile
+
+    LOG.debug('Reading {0}'.format(input_file))
+    f = TFile.Open(input_file)
+    tree = f.Get(TREE_PATH)
+
+    e_branches = [E_PREFIX + '.' + step for step in E_STEPS]
+    mu_branches = [MU_PREFIX + '.' + step for step in MU_STEPS]
+
+    e_cutflow = {step: {} for step in E_STEPS}
+    mu_cutflow = {step: {} for step in MU_STEPS}
+
+    for event in tree:
+        for step, branch in zip(E_STEPS, e_branches):
+            fill_cutflow(e_cutflow[step], event, step, branch)
+
+        for step, branch in zip(MU_STEPS, mu_branches):
+            fill_cutflow(mu_cutflow[step], event, step, branch)
+    f.Close()
+
+    return e_cutflow, mu_cutflow
+
+
+def write_json(e_cutflow, mu_cutflow):
+    import json
+    import os
+    from ntp.commands.setup import RESULTDIR
+
+    e_output = os.path.join(RESULTDIR, 'e_cutflow.json')
+    mu_output = os.path.join(RESULTDIR, 'mu_cutflow.json')
+
+    LOG.info('Creating electron cutflow file: {0}'.format(e_output))
+    with open(e_output, 'w+') as f:
+        f.write(json.dumps(e_cutflow, indent=4))
+
+    LOG.info('Creating muon cutflow file: {0}'.format(mu_output))
+    with open(mu_output, 'w+') as f:
+        f.write(json.dumps(mu_cutflow, indent=4))
+
+if __name__ == '__main__':
+    LOG.debug('Creating JSON files with full event details')
+    input_file = None
+    if len(sys.argv) > 1:
+        input_file = sys.argv[1]
+    else:
+        LOG.error('No input file specified.')
+        sys.exit(-1)
+
+    e_cutflow, mu_cutflow = read_cutflows(input_file)
+
+    write_json(e_cutflow, mu_cutflow)

--- a/python/ntp/commands/create/cutflow/create_table.py
+++ b/python/ntp/commands/create/cutflow/create_table.py
@@ -1,0 +1,72 @@
+from __future__ import print_function, division
+import logging
+import sys
+from ROOT import TFile
+import ntp
+LOG = logging.getLogger('ntp.commands.create.cutflow')
+
+
+MUON_CHANNEL = 'topPairMuPlusJetsSelectionAnalyser/consecutiveCuts'
+ELECTRON_CHANNEL = 'topPairEPlusJetsSelectionAnalyser/consecutiveCuts'
+
+
+def extract_numbers_and_labels(histogram):
+    n_bins = histogram.GetNbinsX()
+    cutflow = []
+    for i in range(1, n_bins + 1):
+        name = histogram.GetXaxis().GetBinLabel(i)
+        value = int(histogram.GetBinContent(i))
+        cutflow.append((name, value))
+    return cutflow
+
+
+def format_cutflow(cutflow):
+    headers = ['Step #', 'Step name', '# events', 'eff', 'total eff']
+    max_len_name = max([len(name) for (name, _) in cutflow])
+    # add some space
+    row_format = "{:<3}\t"
+    row_format += "{:<" + str(max_len_name) + "}\t"
+    row_format += "{:<10}\t"
+    row_format += "{:<3}%\t"
+    row_format += "{:<3}%"
+
+    header_format = row_format.replace('%', "")
+
+    text = [header_format.format(*headers)]
+    text.append('-' * (30 + max_len_name))
+    text.append('')
+    for i, c in enumerate(cutflow):
+        name, value = c
+        total_efficiency = round(value / cutflow[0][1] * 100., 2)
+        efficiency = 100.
+        if i > 0:
+            efficiency = round(value / cutflow[i - 1][1] * 100., 2)
+        outputs = [i, name, value, efficiency, total_efficiency]
+        text.append(row_format.format(*outputs))
+    return text
+
+if __name__ == '__main__':
+    LOG.debug('Creating cutflow table')
+    input_file = None
+    if len(sys.argv) > 1:
+        input_file = sys.argv[1]
+    else:
+        LOG.error('No input file specified.')
+        sys.exit(-1)
+    LOG.debug('Reading {0}'.format(input_file))
+    f = TFile.Open(input_file)
+    mu_hist = f.Get(MUON_CHANNEL)
+    e_hist = f.Get(ELECTRON_CHANNEL)
+
+    mu_cutflow = extract_numbers_and_labels(mu_hist)
+    e_cutflow = extract_numbers_and_labels(e_hist)
+
+    f.Close()
+
+    text = ["Cutflow for electron channel:"]
+    text.extend(format_cutflow(e_cutflow))
+    text.append('')
+    text.append("Cutflow for muon channel:")
+    text.extend(format_cutflow(mu_cutflow))
+    import json
+    print(json.dumps(text))

--- a/python/ntp/commands/diff/__init__.py
+++ b/python/ntp/commands/diff/__init__.py
@@ -1,0 +1,23 @@
+"""
+    diff:
+        Base command for diffing things
+        
+    Usage:
+        diff <thing>
+        
+"""
+import logging
+from .. import Command as C
+
+LOG = logging.getLogger(__name__)
+
+class Command(C):
+
+    def __init__(self, path=__file__, doc=__doc__):
+        super(Command, self).__init__(path, doc)
+
+    def run(self, args, variables):
+        self.__prepare(args, variables)
+        self.__text = "NOT IMPLEMENTED"
+
+        return True

--- a/python/ntp/commands/diff/cutflow/__init__.py
+++ b/python/ntp/commands/diff/cutflow/__init__.py
@@ -1,0 +1,85 @@
+"""
+    diff cutflow:
+        Shows the difference between two cutflows based on their JSON files
+        as created with "create cutflow <ntuple file> format=JSON". 
+        The result will be a JSON file with the difference.
+        
+    Usage:
+        diff cutflow <json 1> <json 2> [cut=<name of a cut>]
+    
+    Parameters:
+        cut: A string representation of the cut you want to compare to.
+             By default all cuts are compared.
+        
+"""
+import logging
+import json
+import os
+from .. import Command as C
+from ntp.commands.setup import RESULTDIR
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(C):
+
+    def __init__(self, path=__file__, doc=__doc__):
+        super(Command, self).__init__(path, doc)
+
+    def run(self, args, variables):
+        self.__prepare(args, variables)
+        json_files = args[0:2]
+        data = self.__get_content(json_files)
+        diff = self.__compare(data)
+        output_file = os.path.join(RESULTDIR, 'diff.json')
+        with open(output_file, 'w+') as f:
+            f.write(json.dumps(diff, indent=4))
+        LOG.info('Created diff JSON file: {0}'.format(output_file))
+
+        return True
+
+    def __get_content(self, json_files):
+        data = []
+        for file_name in json_files:
+            with open(file_name) as f:
+                d = json.load(f)
+                data.append(d)
+        return data
+
+    def __compare(self, data):
+        d1, d2 = data
+        cut = None
+        if 'cut' in self.__variables:
+            cut = self.__variables['cut']
+
+        diff = {}
+        for step, d in d1.items():
+            if cut and not cut == step:
+                continue
+            if not step in d2:
+                LOG.warning(
+                    'Second JSON does not have selection step "{0}"'.format(step))
+                continue
+            diff[step] = {}
+            diff[step]['passing'] = {}
+
+            data1 = d['passing']
+            data2 = d2[step]['passing']
+
+            for run, lumis in data1.items():
+                if run in data2:
+                    lumis2 = data2[run]
+                    diff[step]['passing'][run] = {}
+                    for lumi, events in lumis.items():
+                        if lumi in lumis2:
+                            events2 = lumis2[lumi]
+                            if events == events2:
+                                continue
+                            events_diff = list(set(events) ^ set(events2))
+                            diff[step]['passing'][run][lumi] = events_diff
+
+                        else:
+                            diff[step]['passing'][run][lumi] = events
+                else:
+                    diff[step]['passing'][run] = lumis
+        return diff

--- a/python/ntp/commands/list/samples/__init__.py
+++ b/python/ntp/commands/list/samples/__init__.py
@@ -17,11 +17,11 @@ def get_text_lenghts(samples):
     aliases = []
     datasets = []
 
-    for campaign, sample in samples.items():
+    for _, sample in samples.items():
         aliases.extend(sample.keys())
-        datasets.extend(samples.values())
+        datasets.extend(sample.values())
 
-    len_campaigns = [len(c) for c in campaign]
+    len_campaigns = [len(c) for c in campaigns]
     len_aliases = [len(a) for a in aliases]
     len_datasets = [len(d) for d in datasets]
 

--- a/python/ntp/commands/run/local/__init__.py
+++ b/python/ntp/commands/run/local/__init__.py
@@ -70,6 +70,7 @@ class Command(C):
         'files': '',
         'noop': False,
         'output_file': OUTPUT_FILE,
+        'pset_template': BASE,
     }
 
     def __init__(self, path=__file__, doc=__doc__):
@@ -117,7 +118,7 @@ class Command(C):
         input_files = self.__format_input_files(input_files)
 
         with open(PSET, 'w+') as f:
-            content = BASE.format(
+            content = self.__variables['pset_template'].format(
                 nevents=nevents,
                 input_files=input_files,
                 OUTPUT_FILE=self.__output_file,

--- a/python/ntp/commands/run/sync_ex/__init__.py
+++ b/python/ntp/commands/run/sync_ex/__init__.py
@@ -1,0 +1,79 @@
+"""
+    run sync_ex:
+        Runs the synchronisation exercise on a given data set.
+        Only the first 10,000 events of the first file will be
+        read.
+        
+        
+    Usage:
+            run sync_ex [campaign=<X>]  [dataset=<X>]
+        
+    Parameters:
+            campaign: which campaign to run. Corresponds to the folder
+                      structure in crab/*
+                      Default is 'Spring16'.
+            dataset:  Alias for the single dataset you want to run over. Corresponds
+                      to the file names (without extension) in crab/*/*.py.
+                      Accepts wild-cards and comma-separated lists.
+                      Default is 'TTJets_PowhegPythia8'.
+"""
+import logging
+import os
+from .. import Command as C
+from ntp.interpreter import time_function
+from ntp import NTPROOT
+from ntp.commands.setup import RESULTDIR
+from crab.util import find_input_files
+
+LOG = logging.getLogger(__name__)
+OUTPUT_FILE = os.path.join(RESULTDIR, 'sync_exercise.root')
+
+BASE = """
+import FWCore.ParameterSet.Config as cms
+from run.synchronisation_exercise_cfg import process
+
+process.maxEvents.input = cms.untracked.int32({nevents})
+
+process.TFileService.fileName=cms.string('{OUTPUT_FILE}')
+
+# In order to work around the limitation of 255 parameters to a python function
+# we pass 1 tuple of all the files to the vstring function
+# see
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePoolInputSources#Example_3_More_than_255_input_fi
+process.source.fileNames = cms.untracked.vstring(
+*(
+{input_files},
+)
+)
+
+process.nTuplePFJets.btagCalibrationFile = cms.string('{BTAG_CALIB_FILE}')
+"""
+
+
+class Command(C):
+    DEFAULTS = {
+        'campaign': 'Spring16',
+        'dataset': 'TTJets_PowhegPythia8',
+        'nevents': 10000,
+        'files': '',
+        'output_file': OUTPUT_FILE,
+        'pset_template': BASE,
+    }
+
+    def __init__(self, path=__file__, doc=__doc__):
+        super(Command, self).__init__(path, doc)
+
+    @time_function('run sync_ex', LOG)
+    def run(self, args, variables):
+        self.__prepare(args, variables)
+        input_files = find_input_files(self.__variables, logger=LOG)
+        # take only first file
+        self.__variables['files'] = str(input_files[0])
+        self.__variables['isTTbarMC'] = 1
+
+        from ..local import Command as LocalC
+        run_local = LocalC()
+        rc = run_local.run(args, self.__variables)
+        self.__text = run_local.get_text()
+
+        return rc

--- a/python/ntp/interpreter.py
+++ b/python/ntp/interpreter.py
@@ -111,7 +111,6 @@ def __get_commands(command_path):
             if hasattr(mod, 'Command'):
                 if type(mod.Command) is type(object):
                     commands[relative_path] = mod.Command
-                    LOG.debug('Adding new command: relative_path')
                     __build_hierarchy(hierarchy, relative_path, mod.Command)
         except ImportError, e:
             import traceback

--- a/python/run/synchronisation_exercise_cfg.py
+++ b/python/run/synchronisation_exercise_cfg.py
@@ -1,0 +1,220 @@
+import FWCore.ParameterSet.Config as cms
+
+# Define the CMSSW process
+process = cms.Process("Ntuples")
+
+# Load the standard set of configuration modules
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+
+# Message Logger settings
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.destinations = ['cout', 'cerr']
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+# Set the process options -- Display summary at the end, enable
+# unscheduled execution
+process.options = cms.untracked.PSet(
+    allowUnscheduled=cms.untracked.bool(True),
+    wantSummary=cms.untracked.bool(False),
+)
+
+# print event content
+process.printEventContent = cms.EDAnalyzer("EventContentAnalyzer")
+
+
+# Source
+process.source = cms.Source("PoolSource",
+                            fileNames=cms.untracked.vstring(
+                                # 'root://xrootd.unl.edu//store/mc/RunIIFall15MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1/00000/00DF0A73-17C2-E511-B086-E41D2D08DE30.root',
+                                # 'root://xrootd.unl.edu//store/mc/RunIIFall15MiniAODv2/TT_TuneEE5C_13TeV-amcatnlo-herwigpp/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/10000/0047D532-93B8-E511-AEF5-C4346BC8D568.root'
+
+                                # 'root://xrootd.unl.edu//store/data/Run2015C_25ns/SingleMuon/MINIAOD/16Dec2015-v1/00000/002C22D4-E1AF-E511-AE8E-001E673971CA.root'
+                                # 'file:/storage/db0268/TopCrossSections/NTupleProduction/CMSSW_7_6_3/src/testSingleMuon.root'
+                                'file:/storage/db0268/TopCrossSections/NTupleProduction/CMSSW_7_6_3/src/testMC.root'
+
+                            )
+                            )
+# If you want to run with a json file
+# import FWCore.PythonUtilities.LumiList as LumiList
+# process.source.lumisToProcess = LumiList.LumiList(filename = '/hdfs/TopQuarkGroup/run2/json/Cert_246908-258159_13TeV_PromptReco_Collisions15_25ns_JSON_v3.txt').getVLuminosityBlockRange()
+
+# Use to skip events e.g. to reach a problematic event quickly
+# process.source.skipEvents = cms.untracked.uint32(2000)
+
+# Get options from command line
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing('python')
+
+from BristolAnalysis.NTupleTools.NTupleOptions_cff import *
+getOptions(options)
+
+# If you would like to change the Global Tag e.g. for JEC
+process.load(
+    "Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
+globaltag = ''
+if (options.isData):
+    globaltag = '76X_dataRun2_16Dec2015_v0'  # ReReco+Prompt JECv6
+else:
+    globaltag = '76X_mcRun2_asymptotic_RunIIFall15DR76_v1'  # 25ns MC
+
+print "Using Global Tag : ", globaltag
+process.GlobalTag.globaltag = cms.string(globaltag)
+process.load('JetMETCorrections.Configuration.DefaultJEC_cff')
+# process.load('JetMETCorrections.Configuration.CorrectedJetProducersDefault_cff')
+
+# TT Gen Event configuration
+from BristolAnalysis.NTupleTools.ttGenConfig_cff import setupTTGenEvent
+setupTTGenEvent(process, cms)
+
+# Particle level definitions
+from BristolAnalysis.NTupleTools.pseudoTopConfig_cff import setupPseudoTop
+setupPseudoTop(process, cms)
+
+# Electron VID
+from BristolAnalysis.NTupleTools.ElectronID_cff import setup_electronID
+setup_electronID(process, cms)
+
+# Rerun HBHE filter and others
+from BristolAnalysis.NTupleTools.metFilters_cfi import setupMETFilters
+setupMETFilters(process, cms)
+
+# Rerun MET
+from BristolAnalysis.NTupleTools.MET_Setup_cff import setup_MET
+setup_MET(process, cms, options)
+
+# Custom JEC
+from BristolAnalysis.NTupleTools.Jets_Setup_cff import setup_jets
+setup_jets(process, cms, options)
+
+# Load the selection filters and the selection analyzers
+process.load('BristolAnalysis.NTupleTools.muonSelection_cff')
+process.load('BristolAnalysis.NTupleTools.qcdMuonSelection_cff')
+process.load('BristolAnalysis.NTupleTools.qcdElectronSelection_cff')
+process.load('BristolAnalysis.NTupleTools.electronSelection_cff')
+process.load('BristolAnalysis.NTupleTools.SelectionCriteriaAnalyzer_cfi')
+
+if options.tagAndProbe:
+    process.topPairEPlusJetsSelection.tagAndProbeStudies = cms.bool(True)
+    process.topPairEPlusJetsSelectionTagging.tagAndProbeStudies = cms.bool(
+        True)
+    process.topPairEPlusJetsSelection.jetSelectionInTaggingMode = cms.bool(
+        True)
+    process.topPairEPlusJetsSelectionTagging.jetSelectionInTaggingMode = cms.bool(
+        True)
+
+
+# Maximum Number of Events
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
+
+from BristolAnalysis.NTupleTools.NTupler_cff import *
+setup_ntupler(process, cms)
+
+process.makingNTuples = cms.Path(
+    # process.metFilters *
+    process.egmGsfElectronIDSequence *
+    process.reapplyJEC *
+    process.electronSelectionAnalyzerSequence *
+    process.muonSelectionAnalyzerSequence *
+    process.qcdMuonSelectionAnalyzerSequence *
+    process.qcdElectronSelectionAnalyzerSequence *
+    process.ttGenEvent *
+    process.selectionCriteriaAnalyzer *
+    process.makePseudoTop *
+#     process.printEventContent *
+#     process.nTuples *
+    process.nTupleTree
+)
+
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairMuPlusJetsSelectionTagging_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairMuPlusJetsQCDSelectionTagging1_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairMuPlusJetsQCDSelectionTagging2_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairEPlusJetsSelectionTagging_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairEPlusJetsQCDSelectionTagging_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep uint*_topPairEPlusJetsConversionSelectionTagging_*_*')
+
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairMuPlusJetsSelectionTagging_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairMuPlusJetsQCDSelectionTagging1_*FullSelection*_*')
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairMuPlusJetsQCDSelectionTagging2_*FullSelection*_*')
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairEPlusJetsSelectionTagging_*_*')
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairEPlusJetsQCDSelectionTagging_*FullSelection*_*')
+process.nTupleTree.outputCommands.append(
+    'keep bool_topPairEPlusJetsConversionSelectionTagging_*FullSelection*_*')
+
+
+if not options.isData:
+    # Remove 76X Data 25ns Triggers
+    process.triggerSequence.remove(process.nTupleTriggerEle22erWPLooseGsf)
+    process.triggerSequence.remove(process.nTupleTriggerEle23WPLooseGsf)
+    process.triggerSequence.remove(process.nTupleTriggerIsoMu18)
+    process.triggerSequence.remove(process.nTupleTriggerIsoMu20)
+    process.triggerSequence.remove(process.nTupleTriggerIsoTkMu20)
+    process.triggerSequence.remove(process.nTupleTrigger)
+
+    # Delete removed modules
+    del process.nTupleTriggerEle22erWPLooseGsf, process.nTupleTriggerEle23WPLooseGsf
+    del process.nTupleTriggerIsoMu18, process.nTupleTriggerIsoMu20, process.nTupleTriggerIsoTkMu20
+    del process.nTupleTrigger
+
+if options.isData:
+    # Remove 76X MC 25ns Triggers
+    process.triggerSequence.remove(process.nTupleTriggerEle22erWPLooseGsfMC)
+    process.triggerSequence.remove(process.nTupleTriggerEle23WPLooseGsfMC)
+    process.triggerSequence.remove(process.nTupleTriggerIsoMu18MC)
+    process.triggerSequence.remove(process.nTupleTriggerIsoMu20MC)
+    process.triggerSequence.remove(process.nTupleTriggerIsoTkMu20MC)
+    process.triggerSequence.remove(process.nTupleTrigger)
+
+    # Remove PseudoTop and MC Gen Variables
+    process.makingNTuples.remove(process.makePseudoTop)
+    process.nTuples.remove(process.pseudoTopSequence)
+    process.nTuples.remove(process.nTupleGenMET)
+    process.nTuples.remove(process.nTupleGenJets)
+    process.nTuples.remove(process.nTupleGenEventInfo)
+    process.nTuples.remove(process.nTupleGenParticles)
+
+    # Do not keep Gen branches
+    process.nTupleTree.outputCommands.append('drop *_nTuplePFJets_*Gen*_*')
+
+    # Delete removed modules and sequences (So they do not run on unscheduled)
+    del process.makePseudoTop, process.pseudoTopSequence, process.pseudoTop
+    del process.nTuplePseudoTopJets, process.nTuplePseudoTopLeptons, process.nTuplePseudoTopNeutrinos, process.nTuplePseudoTops
+    del process.nTupleGenMET, process.nTupleGenJets,  process.nTupleGenEventInfo, process.nTupleGenParticles
+    del process.nTupleTriggerEle22erWPLooseGsfMC, process.nTupleTriggerEle23WPLooseGsfMC
+    del process.nTupleTriggerIsoMu18MC, process.nTupleTriggerIsoMu20MC, process.nTupleTriggerIsoTkMu20MC
+    del process.nTupleTrigger
+
+# 76X datasets are all ReReco so far
+process.nTupleEvent.metFiltersInputTag = cms.InputTag(
+    'TriggerResults', '', 'PAT')
+
+# if options.isData and options.isReReco:
+#   process.nTupleEvent.metFiltersInputTag = cms.InputTag('TriggerResults','','PAT')
+
+if not options.isTTbarMC:
+    process.makingNTuples.remove(process.ttGenEvent)
+    process.selectionCriteriaAnalyzer.genSelectionCriteriaInput = cms.VInputTag()
+    del process.ttGenEvent
+
+else:
+    process.nTupleGenEventInfo.isTTbarMC = cms.bool(True)
+
+if not options.printEventContent:
+    process.makingNTuples.remove(process.printEventContent)
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string('sync_exercise.root')
+                                   )
+

--- a/python/run/synchronisation_exercise_cfg.py
+++ b/python/run/synchronisation_exercise_cfg.py
@@ -124,6 +124,7 @@ process.makingNTuples = cms.Path(
     process.makePseudoTop *
 #     process.printEventContent *
 #     process.nTuples *
+    process.nTupleEvent*
     process.nTupleTree
 )
 


### PR DESCRIPTION
The first part to solve issue #194 will include ways to better capture what our current selections are doing. This step is necessary to cross check differences between old and new.

Console:
 - 'run sync_ex' to run the synchronisation exercise (locally)
 - `ntp create cutflow <ntuple file> format=json` (or format=table, default)
 - `ntp diff cutflow <json1> <json2>` which takes the output of `ntp create cutflow` and creates a JSON file with the difference. Useful to track changes from one selection to another

MISC:
 - more documentation & nodes
