### PR TITLE
New b-tag SF code

### DIFF
--- a/docs/twikis.md
+++ b/docs/twikis.md
@@ -1,1 +1,5 @@
 https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePythonTips
+
+B-Tagging:
+https://twiki.cern.ch/twiki/bin/view/CMS/BTagCalibration
+https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80X

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
 	"name": "NTupleProduction",
-	"version": "CMSSW_8_0_9",
-	"cmssw_version": "CMSSW_8_0_9",
-	"scram_arch": "slc6_amd64_gcc493",
+	"version": "CMSSW_8_0_14",
+	"cmssw_version": "CMSSW_8_0_14",
+	"scram_arch": "slc6_amd64_gcc530",
 	"summary": "For the creation of n-tuples",
 	"author": "Bristol Top Quark Group",
 	"source": "https://github.com/BristolTopGroup/NTupleProduction.git",

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -3,14 +3,15 @@
 </library>
 
 <library name = "BristolAnalysisNTupleProductionPlugins_userdata" file="userdata/*.cc">
-	<use name="FWCore/Framework"/>
-	<use name="FWCore/PluginManager"/>
-	<use name="FWCore/ParameterSet"/>
-	<use name="RecoEgamma/EgammaTools"/>
-	<use name="DataFormats/PatCandidates"/>
+	<use name="CondFormats/BTauObjects"/>
 	<use name="CondFormats/JetMETObjects"/>
+	<use name="CondTools/BTau"/>
+	<use name="DataFormats/PatCandidates"/>
+	<use name="FWCore/Framework"/>
+	<use name="FWCore/ParameterSet"/>
+	<use name="FWCore/PluginManager"/>
 	<use name="HLTrigger/HLTcore"/>
 	<use name="JetMETCorrections/Objects"/>
 	<use name="PhysicsTools/Utilities"/>
-	<use name="CondFormats/BTauObjects"/>
+	<use name="RecoEgamma/EgammaTools"/>
 </library>


### PR DESCRIPTION
With the introduction of `CMSSW_8_0_13` (or `CMSSW_8_1_X`) the way to access b-tag scale factors has changed.
I've updated the CMSSW version to the latest `8_0_X` (`X = 14`) and updated the code.

It seems that the b-tag SFs are almost ready for 2016, so this will come next.