### PR TITLE
ntp.utils

### DIFF
--- a/python/ntp/commands/create/tarball/__init__.py
+++ b/python/ntp/commands/create/tarball/__init__.py
@@ -113,3 +113,11 @@ class Command(C):
 
     def get_tar_files(self):
         return self.__tar_files
+
+    @staticmethod
+    def tarballs_exist():
+        cmssw_tars = [CMSSW_TAR + '.tar', CMSSW_TAR + '.tar.gz']
+        cmssw_exists = any([os.path.exists(p) for p in cmssw_tars])
+        ntp_tars = [NTP_TAR + '.tar', NTP_TAR + '.tar.gz']
+        ntp_exists = any([os.path.exists(p) for p in ntp_tars])
+        return cmssw_exists and ntp_exists

--- a/python/ntp/commands/run/condor/__init__.py
+++ b/python/ntp/commands/run/condor/__init__.py
@@ -206,6 +206,8 @@ class Command(C):
 
     def __create_tar_file(self, args, variables):
         from ntp.commands.create.tarball import Command as TarCommand
+        if self.__variables['noop'] and TarCommand.tarballs_exist():
+            return
         c = TarCommand()
         c.run(args, variables)
         self.__text += c.__text

--- a/python/ntp/utils/__init__.py
+++ b/python/ntp/utils/__init__.py
@@ -1,0 +1,33 @@
+"""
+    A small collections of functions that are useful in more than one place.
+    All of this should move to DailyPythonScripts.
+"""
+
+
+def make_even_chunks(list_of_things, n_chunks):
+    """
+        Creates even chunks given a list and the number of chunks
+    """
+    last = 0
+    n = n_chunks
+    l = list_of_things
+    for i in range(1, n + 1):
+        cur = int(round(i * (len(l) / n)))
+        yield l[last:cur]
+        last = cur
+
+
+def find_latest_iteration(directories):
+    """
+        Selects the latest iteration of a workflow based on the numbering
+        of directories.
+        Expects a list of directories of the form
+        <path>/<name>_<number>
+        and will return the directory with the highest number.
+        Will return 0 if no directories are given.
+    """
+    numbers = [0]
+    for d in directories:
+        number = int(d.split('_')[-1])
+        numbers.append(number)
+    return max(numbers)

--- a/python/ntp/utils/data/__init__.py
+++ b/python/ntp/utils/data/__init__.py
@@ -1,0 +1,19 @@
+"""
+    A collection of functions that operate on data
+"""
+
+
+def is_real_data(file_path):
+    """
+        Tries to determine from the file path if the file is real data or
+        simulation.
+    """
+    real_data_examples = [
+        'SingleElectron', 'SingleMuon', 'ElectronHad', 'SingleMu']
+
+    return any([e in file_path for e in real_data_examples])
+
+
+def is_ttbar_mc(file_path):
+    ttbar_mc_examples = ['TTJets', 'TTZ', 'TT_']
+    return any([e in file_path for e in ttbar_mc_examples])

--- a/python/ntp/utils/hdfs/__init__.py
+++ b/python/ntp/utils/hdfs/__init__.py
@@ -1,0 +1,10 @@
+import getpass
+import os
+from crab.base import __version__
+
+HDFS_STORE_BASE = os.path.join(
+    '/hdfs',
+    'TopQuarkGroup',
+    getpass.getuser(),
+    __version__
+)


### PR DESCRIPTION
In preparation of the condor split for NTP, AT & DPS, I've extracted some functions that are useful in each.

One important change is the storage path.
Previously:
`/hdfs/TopQuarkGroup/<user>/ntuple/<version>`
now
`/hdfs/TopQuarkGroup/<user>/<version>/ntuple`

This allows to group AT and DPS output by version:
`/hdfs/TopQuarkGroup/<user>/<version>/atOutput`
`/hdfs/TopQuarkGroup/<user>/<version>/dpsOutput`

Also added a check for the existence of tarballs for faster testing (will not recreate tarballs if you just test the condor file creation, e.g. with `ntp run condor noop=1`)
