### PR TITLE
Moving conda to new, common location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ install:
 
 script:
   - python python/ntp/utils/test/test_utils.py
+  - ./test/test.sh
 cache: apt

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -85,30 +85,34 @@ if [ "$vomsInfo" == "" ]; then
   fi
 fi
 
-# miniconda setup for modern python and additional python packages
-if [ ! -d "${HEP_PROJECT_ROOT}/external" ] ; then
-	mkdir ${HEP_PROJECT_ROOT}/external
-fi
-
-if [ ! -d "${HEP_PROJECT_ROOT}/external/miniconda" ] ; then
+TOPQ_CONDA_PATH=/software/TopQuarkGroup/miniconda; export TOPQ_CONDA_PATH
+if [ ! -d "${TOPQ_CONDA_PATH}" ] ; then
+  # just create all parent folders except miniconda
+  echo "Could not find conda install in ${TOPQ_CONDA_PATH}. Installing conda ..."
+  mkdir -p ${TOPQ_CONDA_PATH}; rmdir ${TOPQ_CONDA_PATH}
 	wget -nv https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
-	bash miniconda.sh -b -p ${HEP_PROJECT_ROOT}/external/miniconda
-	PATH=${HEP_PROJECT_ROOT}/external/miniconda/bin:$PATH; export PATH
+	bash miniconda.sh -b -p ${TOPQ_CONDA_PATH}
+	PATH=${TOPQ_CONDA_PATH}/bin:$PATH; export PATH
 	rm -f miniconda.sh
+  echo "Finished conda installation, creating new conda environment"
 	conda update conda -y
 	conda update pip -y
 	conda install git wget pycurl psutil -y
 	conda config --add channels http://conda.anaconda.org/NLeSC
     conda config --set show_channel_urls yes
 	# python modules
-	conda create -n ntp python=2.7 root=6 root-numpy numpy matplotlib nose sphinx pytables rootpy
+	conda create -n ntp python=2.7 root=6 root-numpy numpy matplotlib nose sphinx pytables rootpy pandas -y
+  echo "Created conda environment, installing basic dependencies"
 	source activate ntp
 	pip install -U python-cjson
 	pip install -U uncertainties
 	pip install -U git+https://github.com/kreczko/hepshell.git
 	# clean the cache (downloaded tarballs)
 	conda clean -t -y
+  # give the group write access
+  chmod g+r -R ${TOPQ_CONDA_PATH}
 else
-	PATH=${HEP_PROJECT_ROOT}/external/miniconda/bin:$PATH; export PATH
+  echo "Found conda install in ${TOPQ_CONDA_PATH}, activating..."
+	PATH=${TOPQ_CONDA_PATH}/bin:$PATH; export PATH
 	source activate ntp
 fi

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -107,9 +107,7 @@ if [ ! -d "${TOPQ_CONDA_PATH}" ] ; then
   echo "Created conda environment, installing basic dependencies"
 	source activate ntp
   conda install git wget pycurl -y
-	pip install -U python-cjson
-	pip install -U uncertainties
-	pip install -U git+https://github.com/kreczko/hepshell.git
+	pip install -U -r requirements.txt
 	# clean the cache (downloaded tarballs)
 	conda clean -t -y
   # give the group write access

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -98,13 +98,15 @@ if [ ! -d "${TOPQ_CONDA_PATH}" ] ; then
   echo "Finished conda installation, creating new conda environment"
 	conda update conda -y
 	conda update pip -y
-	conda install git wget pycurl psutil -y
+	conda install psutil -y
 	conda config --add channels http://conda.anaconda.org/NLeSC
     conda config --set show_channel_urls yes
 	# python modules
-	conda create -n ntp python=2.7 root=6 root-numpy numpy matplotlib nose sphinx pytables rootpy pandas -y
+	conda create -n ntp python=2.7 root=6 root-numpy numpy matplotlib nose \
+  sphinx pytables rootpy pandas -y
   echo "Created conda environment, installing basic dependencies"
 	source activate ntp
+  conda install git wget pycurl -y
 	pip install -U python-cjson
 	pip install -U uncertainties
 	pip install -U git+https://github.com/kreczko/hepshell.git

--- a/metadata.json
+++ b/metadata.json
@@ -28,11 +28,6 @@
 			"destination": "",
 			"provider": "git-cms-merge-topic"
 		},{
-			"name": "htcondenser",
-			"source": "git+https://github.com/kreczko/htcondenser.git@setup",
-			"destination": "",
-			"provider": "pip"
-		},{
 			"name": "ganga",
 			"source": "ganga",
 			"destination": "",

--- a/python/ntp/commands/__init__.py
+++ b/python/ntp/commands/__init__.py
@@ -5,7 +5,8 @@ import copy
 
 LOG = logging.getLogger(__name__)
 
-from hepshell.commands import Command as BaseCommand
+
+from hepshell.command import Command as BaseCommand
 
 class Command(BaseCommand):
     """Base class for all commands"""

--- a/python/ntp/commands/create/tarball/__init__.py
+++ b/python/ntp/commands/create/tarball/__init__.py
@@ -98,6 +98,7 @@ class Command(C):
     def __prepare_ntp(self):
         ignore = ['data', '.git*', 'workspace*', '*.root', '.*']
         ignore.extend(['src', 'plugins', 'docs', 'interface'])
+        ignore.extend(['external'])
         ignore = [os.path.join(NTPROOT, i) for i in ignore]
         ignore.append('git-*')
         self.__make_snapshot(NTPROOT, NTP_TAR, *ignore)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-cjson
+uncertainties
+-e git+https://github.com/kreczko/hepshell.git#egg=hepshell
+-e git+https://github.com/raggleton/htcondenser.git#egg=htcondenser

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+echo "Testing hepshell"
+python -c 'import hepshell'
+echo "Testing ntp"
+python -c 'import ntp'
+echo "Testing pycurl"
+python -c 'import pycurl'
+echo "Testing ROOT, rootpy & dps"
+python -c 'import ROOT; import rootpy; import dps'


### PR DESCRIPTION
As per #255 the PR moves the miniconda location from `external/miniconda` to `/software/TopQuarkGroup/miniconda`. The new miniconda path is accessible via the ENV variable `TOPQ_CONDA_PATH`.

As a little bonus: a bug fix to match the new command location in `hepshell`