### PR TITLE
added lazy loading for ROOT, rootpy and dps modules

### DIFF
--- a/python/ntp/commands/calculate/systematics/__init__.py
+++ b/python/ntp/commands/calculate/systematics/__init__.py
@@ -36,14 +36,6 @@ from hepshell.interpreter import time_function
 from ntp.commands.run import Command as C
 from ntp.commands.setup import DPS_RESULTDIR
 
-from dps.config.xsection import XSectionConfig
-from dps.utils.systematic import append_PDF_uncertainties, print_dictionary,\
-    get_symmetrised_systematic_uncertainty, generate_covariance_matrices,\
-    get_measurement_with_total_systematic_uncertainty,\
-    write_normalised_xsection_measurement, get_normalised_cross_sections
-from dps.utils.file_utilities import make_folder_if_not_exists
-from dps.config.variable_binning import bin_edges_vis
-
 LOG = logging.getLogger(__name__)
 
 JSON_PATH = os.path.join(
@@ -70,6 +62,15 @@ class Command(C):
 
     @time_function('calculate systematics', LOG)
     def run(self, args, variables):
+        from dps.config.xsection import XSectionConfig
+        from dps.utils.systematic import append_PDF_uncertainties
+        from dps.utils.systematic import print_dictionary,\
+            get_symmetrised_systematic_uncertainty, generate_covariance_matrices,\
+            get_measurement_with_total_systematic_uncertainty,\
+            write_normalised_xsection_measurement, get_normalised_cross_sections
+        from dps.utils.file_utilities import make_folder_if_not_exists
+        from dps.config.variable_binning import bin_edges_vis
+
         self.__prepare(args, variables)
         self.__text = "Running calculate systematics"
         centre_of_mass_energy = self.__variables['centre_of_mass_energy']

--- a/python/ntp/commands/get/ttjet/normalisation/__init__.py
+++ b/python/ntp/commands/get/ttjet/normalisation/__init__.py
@@ -38,9 +38,6 @@ from ntp.commands.run import Command as C
 from ntp.commands.setup import DPS_RESULTDIR
 from ntp.commands.create.dps.configs import DPS_CONFIGDIR
 
-from dps.analysis.xsection.lib import closure_tests as CTs
-from dps.config.xsection import XSectionConfig
-
 LOG = logging.getLogger(__name__)
 INPUT_PATH = os.path.join(
     DPS_CONFIGDIR, 'measurements', 'background_subtraction')
@@ -61,6 +58,8 @@ class Command(C):
     }
 
     def __init__(self, path=__file__, doc=__doc__):
+        from dps.analysis.xsection.lib import closure_tests as CTs
+        from dps.config.xsection import XSectionConfig
         variables = '|'.join(XSectionConfig.variables)
         closure_tests = '|'.join(CTs.keys())
         doc = doc.format(variables=variables, closure_tests=closure_tests)
@@ -74,6 +73,7 @@ class Command(C):
 
     def __run(self):
         import importlib
+        from dps.config.xsection import XSectionConfig
         get_ttjet_normalisation = importlib.import_module(
             'dps.analysis.xsection.01_get_ttjet_normalisation', 'dps.analysis.xsection')
 

--- a/python/ntp/commands/unfold/and/measure/__init__.py
+++ b/python/ntp/commands/unfold/and/measure/__init__.py
@@ -45,18 +45,6 @@ from hepshell.interpreter import time_function
 from ntp.commands.run import Command as C
 from ntp.commands.setup import DPS_RESULTDIR
 
-# from dps.config.xsection import XSectionConfig
-# import dps.config.RooUnfold as unfoldCfg
-# from dps.utils.file_utilities import read_data_from_JSON, write_data_to_JSON
-# from dps.utils.Calculation import calculate_xsection, calculate_normalised_xsection, \
-#     combine_complex_results
-
-unfold_and_measure = importlib.import_module(
-    'dps.analysis.xsection.02_unfold_and_measure', 'dps.analysis.xsection')
-get_unfolded_normalisation = unfold_and_measure.get_unfolded_normalisation
-calculate_xsections = unfold_and_measure.calculate_xsections
-calculate_normalised_xsections = unfold_and_measure.calculate_normalised_xsections
-
 LOG = logging.getLogger(__name__)
 
 JSON_PATH = os.path.join(


### PR DESCRIPTION
Separated it out from #256 for better review of `ntp run ntuple`"

> Since testing is quite annoying otherwise, I also added lazy module loading for the DPS commands such that ROOT gets only loaded once it is needed (had up to 40s load times!).


Since this is not changing any functionality but just delaying the import of `dps`, should be instantly mergable.