### PR TITLE
TTZ Event content and some fixes

### DIFF
--- a/interface/BristolNTuple_GenEventInfo.h
+++ b/interface/BristolNTuple_GenEventInfo.h
@@ -14,6 +14,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 
 namespace TTbarDecay {
 enum value {
@@ -31,6 +32,21 @@ enum value {
 	NumberOfDecayModes
 };
 }
+
+namespace ZDecay {
+enum value {
+  NoZFound,
+  ZToEE,
+  ZToMuMu,
+  ZToTauTau,
+  ZTo2NuE,
+  ZTo2NuMu,
+  ZTo2NuTau,
+  NotInterestingZDecay,
+  NumberOfDecayModes
+};
+}
+
 class BristolNTuple_GenEventInfo: public edm::EDProducer {
 
 public:
@@ -52,7 +68,15 @@ private:
 	const edm::EDGetTokenT<TtGenEvent >  tt_gen_event_input_;
 	const double minGenJetPt_, maxGenJetAbsoluteEta_;
 	const std::string prefix_, suffix_;
+	edm::EDGetTokenT<edm::View<reco::GenParticle> > prunedGenToken_;
+	edm::EDGetTokenT<edm::View<pat::PackedGenParticle> > packedGenToken_;
+
+  bool isAncestor(const reco::Candidate * ancestor, const reco::Candidate * particle) const;
+  std::vector<const pat::PackedGenParticle*> getZDecayParticles(const reco::Candidate* zBoson,
+      const edm::Handle<edm::View<pat::PackedGenParticle> >& packed) const;
+  ZDecay::value getZDecay(const std::vector<const pat::PackedGenParticle*>& decayParticles) const;
+  void addTTZContent(edm::Event &, const edm::EventSetup &);
 };
 
 #endif
-	
+

--- a/python/BristolNTuple_GenEventInfo_cfi.py
+++ b/python/BristolNTuple_GenEventInfo_cfi.py
@@ -27,5 +27,7 @@ nTupleGenEventInfo = cms.EDProducer("BristolNTuple_GenEventInfo",
 
     minGenJetPt = cms.double(20.),
     maxGenJetAbsoluteEta = cms.double(999.),
+    packedGenParticles = cms.InputTag("packedGenParticles"),
+    prunedGenParticles = cms.InputTag("prunedGenParticles")
 
 )

--- a/python/crab/Moriond17/TTZToLLNUNU_M10.py
+++ b/python/crab/Moriond17/TTZToLLNUNU_M10.py
@@ -1,0 +1,15 @@
+import crab.base
+from copy import deepcopy
+NAME = __file__.split('/')[-1].replace('.pyc', '')
+NAME = NAME.split('/')[-1].replace('.py', '')
+CAMPAIGN = __file__.split('/')[-2]
+
+config = deepcopy(crab.base.config)
+config.General.requestName = NAME
+config.Data.outputDatasetTag = NAME
+config.Data.outLFNDirBase += '/' + CAMPAIGN
+config.Data.inputDataset = '/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 10
+config.JobType.pyCfgParams = ['isTTbarMC=1']
+

--- a/python/crab/Spring16/TTZToLLNUNU_M10.py
+++ b/python/crab/Spring16/TTZToLLNUNU_M10.py
@@ -11,5 +11,5 @@ config.Data.outLFNDirBase += '/' + CAMPAIGN
 config.Data.inputDataset = '/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM'
 config.Data.splitting = 'FileBased'
 config.Data.unitsPerJob = 10
-
+config.JobType.pyCfgParams = ['isTTbarMC=1']
 

--- a/src/BristolNTuple_MET.cc
+++ b/src/BristolNTuple_MET.cc
@@ -32,7 +32,7 @@ void BristolNTuple_MET::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 	std::auto_ptr<double> py(new double(patMET.py()));
 	std::auto_ptr<double> met(new double(patMET.pt()));
 	std::auto_ptr<double> phi(new double(patMET.phi()));
-	std::auto_ptr<double> significance(new double(patMET.significance()));
+	std::auto_ptr<double> significance(new double(patMET.metSignificance()));
 	std::auto_ptr<std::vector<unsigned int > > METUncertaintyTypes(new std::vector<unsigned int>() );
 	std::auto_ptr<std::vector<double> > METUncertaintiesPt(new std::vector<double>() );
 	std::auto_ptr<std::vector<double> > METUncertaintiesPx(new std::vector<double>() );


### PR DESCRIPTION
Additions:
 - Z kinematics (p<sub>T</sub>, &eta;, &phi;, etc) & generator info (decay channel, status)
 - Z decay particles (ee, &mu;&mu;, neutrinos)
 - Moriond17 TTZ sample

Changes:
 - TTZ now running with `isTTBar=1`
 - fixed MET significance (f7d191c)
 - ttbar generator information now uses `-9999.9` as init values for p<sub>T</sub>

Cleanup:
 - generator info variables now initialised in the same line they are defined (~ 65 lines of code removed)
 - removed commented out code

Ran this with master + changes on TTJet and TTZ (everything not using  `isTTBar=1` will not access the code) and the results are available on soolin for inspection:
 - /storage/phxlk/testing/ttz/TTJets_PowhegPythia8_Test_ntuple.root
 - /storage/phxlk/testing/ttz/TTZToLLNuNu_Test_ntuple.root

