### PR TITLE
Global variables for each selection

### DIFF
--- a/interface/PatUtilities.h
+++ b/interface/PatUtilities.h
@@ -6,6 +6,7 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -29,5 +30,64 @@ double getSmearedJetPtScale(const pat::Jet& jet, int jet_smearing_systematic);
 pat::JetCollection applyNewJec( pat::JetCollection jets, const JetCorrector* corrector, edm::Event& iEvent, const edm::EventSetup& iSetup );
 
 float getJECForJet(const pat::Jet jet, const JetCorrector* corrector, edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+namespace ntp {
+namespace utils {
+/**
+ * @param jets
+ * @return pT sum of all jets
+ */
+double ht(const pat::JetCollection& jets);
+/**
+ *
+ * @param jets
+ * @param met
+ * @param lepton
+ * @return ht + MET.et() + lepton.pt()
+ */
+double st(const pat::JetCollection& jets, const pat::MET& met, const reco::Candidate* lepton);
+/**
+ *
+ * @param met
+ * @param lepton
+ * @return transverse momentum of the leptonically decaying W boson
+ */
+double wpt(const pat::MET& met, const reco::Candidate* lepton);
+/**
+ *
+ * @param met
+ * @param lepton
+ * @return transverse mass of the leptonically decaying W boson
+ */
+double mt(const pat::MET& met, const reco::Candidate* lepton);
+/**
+ * Calculates the invariant mass of three jets where the triplet of jets is
+ * chosen by having the largest (vector) sum of pT
+ * @param jets
+ * @return invariant mass of three jets
+ */
+double m3(const pat::JetCollection& jets);
+/**
+ * @param jets
+ * @param lepton
+ * @return angle between the lepton and the closest b-tagged jet
+ */
+double angle_bl(const pat::JetCollection& jets, const reco::Candidate* lepton);
+/**
+ * @param jets
+ * @param lepton
+ * @return invariant mass of the lepton and the closest b-tagged jet
+ */
+double m_bl(const pat::JetCollection& jets, const reco::Candidate* lepton);
+
+/**
+ *
+ * @param jets
+ * @param lepton
+ * @return closest jet to the given lepton
+ */
+pat::Jet getClosestJet(const pat::JetCollection& jets, const reco::Candidate* lepton);
+}
+}
 
 #endif 

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -14,4 +14,5 @@
 	<use name="JetMETCorrections/Objects"/>
 	<use name="PhysicsTools/Utilities"/>
 	<use name="RecoEgamma/EgammaTools"/>
+	<use name="BristolAnalysis/NTupleTools"/>
 </library>

--- a/plugins/UnfoldingAnalyser.cc
+++ b/plugins/UnfoldingAnalyser.cc
@@ -1,3 +1,7 @@
+/**
+ * @deprecated
+ */
+
 #include "BristolAnalysis/NTupleTools/plugins/UnfoldingAnalyser.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"

--- a/plugins/UnfoldingProducer.cc
+++ b/plugins/UnfoldingProducer.cc
@@ -1,3 +1,7 @@
+/**
+ *
+ * @deprecated
+ */
 #include "BristolAnalysis/NTupleTools/plugins/UnfoldingProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"

--- a/plugins/userdata/EventUserData.cc
+++ b/plugins/userdata/EventUserData.cc
@@ -1,0 +1,182 @@
+/**
+ * Produces global variables and similar:
+ *  - HT: scalar sum of pT of all jets above a threshold
+ *  - ST: HT + MET + signal lepton pT
+ *  -
+ *
+ *  Why do we not include this in BristolNTuple_Event.cc?
+ *  BristolNTuple_Event is meant to run once per event,
+ *  while this module can run N times (once for each selection, jet energy variation, etc).
+ */
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "BristolAnalysis/NTupleTools/interface/PatUtilities.h"
+
+namespace ntp {
+namespace userdata {
+
+class EventUserData: public edm::stream::EDProducer<> {
+public:
+  typedef std::vector<unsigned int> IndexCollection;
+  explicit EventUserData(const edm::ParameterSet&);
+  ~EventUserData();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginStream(edm::StreamID) override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endStream() override;
+
+  pat::JetCollection getCleanedJets(const pat::JetCollection& jets, const IndexCollection& indices);
+  // inputs
+  const edm::EDGetTokenT<std::vector<reco::Vertex> > vtxInputTag_;
+  edm::EDGetToken electronInputTag_, muonInputTag_, jetInputTag_, bJetInputTag_, metInputTag_;
+  bool isElectron_;
+
+  std::string prefix_;
+  std::string suffix_;
+
+};
+
+EventUserData::EventUserData(const edm::ParameterSet& iConfig) :
+        vtxInputTag_(
+            consumes < std::vector<reco::Vertex> > (iConfig.getParameter < edm::InputTag > ("vertexCollection"))),
+        electronInputTag_(
+            consumes < std::vector<pat::Electron> > (iConfig.getParameter < edm::InputTag > ("electronCollection"))),
+        muonInputTag_(consumes < std::vector<pat::Muon> > (iConfig.getParameter < edm::InputTag > ("muonCollection"))),
+        jetInputTag_(consumes < std::vector<pat::Jet> > (iConfig.getParameter < edm::InputTag > ("jetCollection"))), //
+        bJetInputTag_(consumes < std::vector<pat::Jet> > (iConfig.getParameter < edm::InputTag > ("bJetCollection"))), //
+        metInputTag_(consumes < std::vector<pat::MET> > (iConfig.getParameter < edm::InputTag > ("metInputTag"))), //
+        isElectron_(iConfig.getParameter<bool>("isElectron")), //
+        prefix_(iConfig.getParameter < std::string > ("prefix")), //
+        suffix_(iConfig.getParameter < std::string > ("suffix"))
+{
+  //register your products
+  produces<double>(prefix_ + "HT" + suffix_);
+  produces<double>(prefix_ + "ST" + suffix_);
+  produces<double>(prefix_ + "M3" + suffix_);
+  produces<double>(prefix_ + "Mbl" + suffix_);
+  produces<double>(prefix_ + "anglebl" + suffix_);
+  produces<double>(prefix_ + "MT" + suffix_);
+  produces<double>(prefix_ + "WPT" + suffix_);
+}
+
+EventUserData::~EventUserData()
+{
+
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
+
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void EventUserData::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle < std::vector<pat::Electron> > electrons;
+  iEvent.getByToken(electronInputTag_, electrons);
+
+  edm::Handle < std::vector<pat::Muon> > muons;
+  iEvent.getByToken(muonInputTag_, muons);
+
+  edm::Handle < std::vector<pat::Jet> > jetHandle;
+  iEvent.getByToken(jetInputTag_, jetHandle);
+  const pat::JetCollection& jets = *jetHandle.product();
+
+  edm::Handle < std::vector<pat::Jet> > bJetHandle;
+  iEvent.getByToken(bJetInputTag_, bJetHandle);
+  const pat::JetCollection& bjets = *bJetHandle.product();
+
+  edm::Handle < std::vector<pat::MET> > mets;
+  iEvent.getByToken(metInputTag_, mets);
+
+  const pat::MET & met(mets->at(0));
+
+  const double DEFAULT_VALUE=-999;
+  std::auto_ptr<double> ht(new double(utils::ht(jets)));
+  std::auto_ptr<double> st(new double(DEFAULT_VALUE));
+  std::auto_ptr<double> m3(new double(DEFAULT_VALUE));
+  std::auto_ptr<double> m_bl(new double(DEFAULT_VALUE));
+  std::auto_ptr<double> angle_bl(new double(-9));
+  std::auto_ptr<double> mt(new double(DEFAULT_VALUE));
+  std::auto_ptr<double> wpt(new double(DEFAULT_VALUE));
+
+  if (jets.size() >= 3)
+    *m3 = utils::m3(jets);
+
+  if ((electrons.isValid() && isElectron_) ||  (muons.isValid() && !isElectron_)) {
+    const reco::Candidate* lepton =
+        isElectron_ ?
+            (reco::Candidate*) &electrons->front() :
+            (reco::Candidate*) &muons->front();
+    if (lepton) {
+      if (bjets.size() > 0) {
+        *m_bl = utils::m_bl(bjets, lepton);
+        *angle_bl = utils::angle_bl(bjets, lepton);
+      }
+      *st = utils::st(jets, met, lepton);
+      *mt = utils::mt(met, lepton);
+      *wpt = utils::wpt(met, lepton);
+    }
+
+  }
+
+  iEvent.put(ht, prefix_ + "HT" + suffix_);
+  iEvent.put(st, prefix_ + "ST" + suffix_);
+  iEvent.put(m3, prefix_ + "M3" + suffix_);
+  iEvent.put(m_bl, prefix_ + "Mbl" + suffix_);
+  iEvent.put(angle_bl, prefix_ + "anglebl" + suffix_);
+  iEvent.put(mt, prefix_ + "MT" + suffix_);
+  iEvent.put(wpt, prefix_ + "WPT" + suffix_);
+
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void EventUserData::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void EventUserData::endStream()
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void EventUserData::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE (EventUserData);
+} //userdata
+} //ntp

--- a/python/run/miniAODToNTuple_cfg.py
+++ b/python/run/miniAODToNTuple_cfg.py
@@ -129,6 +129,9 @@ process.nTupleGenEventInfo.isTTbarMC = cms.bool(isTTbarMC)
 # mapping between MiniAOD collections and our object selections
 process.load('BristolAnalysis.NTupleTools.indices_cff')
 
+# adds process.eventUserDataSequence
+process.load('BristolAnalysis.NTupleTools.userdata.EventUserData_cff')
+
 
 if isTTbarMC:
     process.makingNTuples = cms.Path(
@@ -143,6 +146,7 @@ if isTTbarMC:
         process.selectionCriteriaAnalyzer *
         process.makePseudoTop *
         process.indexSequence *
+        process.eventUserDataSequence *
         process.printEventContent *
         process.nTuples *
         process.nTupleTree
@@ -158,6 +162,7 @@ else:
         process.qcdElectronSelectionAnalyzerSequence *
         process.selectionCriteriaAnalyzer *
         process.indexSequence *
+        process.eventUserDataSequence *
         process.printEventContent *
         process.nTuples *
         process.nTupleTree
@@ -178,6 +183,7 @@ process.nTupleTree.outputCommands.extend(
         'keep bool_topPairEPlusJetsQCDSelectionTagging_*FullSelection*_*',
         'keep bool_topPairEPlusJetsConversionSelectionTagging_*FullSelection*_*',
         'keep uint*_*Indices*_*_*',
+        'keep double_eventUserData*_*_*',
     ]
 )
 
@@ -311,6 +317,7 @@ if is2016:
 process.load('BristolAnalysis.NTupleTools.userdata.ElectronUserData_cfi')
 process.load('BristolAnalysis.NTupleTools.userdata.MuonUserData_cfi')
 process.load('BristolAnalysis.NTupleTools.userdata.JetUserData_cfi')
+
 if options.useJECFromFile:
     process.jetUserData.jetCollection=cms.InputTag("patJetsReapplyJEC")
 

--- a/python/userdata/EventUserData_cff.py
+++ b/python/userdata/EventUserData_cff.py
@@ -1,0 +1,51 @@
+import FWCore.ParameterSet.Config as cms
+
+from BristolAnalysis.NTupleTools.userdata.EventUserData_cfi import eventUserData
+
+# electron signal selection
+eventUserDataTopPairElectronPlusJetsSelection = eventUserData.clone()
+# electron main QCD control region
+eventUserDataTopPairElectronPlusJetsConversionSelection = eventUserData.clone(
+    prefix='TopPairElectronPlusJetsConversionSelection.',
+    electronCollection='goodConversionElectrons',
+    jetCollection='goodJetsEConversionRegion',
+    bJetCollection='goodBJetsEConversionRegion',
+)
+# electron secondary QCD control region
+eventUserDataTopPairElectronPlusJetsNonIsoSelection = eventUserData.clone(
+    prefix='TopPairElectronPlusJetsQCDSelection.',
+    electronCollection='goodNonIsoElectrons',
+    jetCollection='goodJetsENonIsoRegion',
+    bJetCollection='goodBJetsENonIsoRegion',
+)
+
+# muon signal selection
+eventUserDataTopPairMuonPlusJetsSelection = eventUserData.clone(
+    prefix='TopPairMuonPlusJetsSelection.',
+    isElectron=False
+)
+# muon main QCD control region
+eventUserDataTopPairMuonPlusJetsQCD1Selection = eventUserData.clone(
+    prefix='TopPairMuonPlusJetsQCDSelection3toInf.',
+    muonCollection='goodNonIsoR1Muons',
+    jetCollection='goodJetsMuNonIsoR1Region',
+    bJetCollection='goodBJetsMuNonIsoR1Region',
+)
+# muon secondary QCD control region
+eventUserDataTopPairMuonPlusJetsQCD2Selection = eventUserData.clone(
+    prefix='TopPairMuonPlusJetsQCDSelection1p5to3.',
+    muonCollection='goodNonIsoR2Muons',
+    jetCollection='goodJetsMuNonIsoR2Region',
+    bJetCollection='goodBJetsMuNonIsoR2Region',
+)
+
+eventUserDataSequence = cms.Sequence(
+    # electrons
+    eventUserDataTopPairElectronPlusJetsSelection +
+    eventUserDataTopPairElectronPlusJetsConversionSelection +
+    eventUserDataTopPairElectronPlusJetsNonIsoSelection +
+    # muons
+    eventUserDataTopPairMuonPlusJetsSelection +
+    eventUserDataTopPairMuonPlusJetsQCD1Selection +
+    eventUserDataTopPairMuonPlusJetsQCD2Selection
+)

--- a/python/userdata/EventUserData_cfi.py
+++ b/python/userdata/EventUserData_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+eventUserData = cms.EDProducer(
+    'EventUserData',
+    vertexCollection=cms.InputTag('offlineSlimmedPrimaryVertices'),
+    electronCollection=cms.InputTag("goodElectrons"),
+    muonCollection=cms.InputTag("goodMuons"),
+    jetCollection=cms.InputTag("goodJets"),
+    bJetCollection=cms.InputTag("goodBJets"),
+    metInputTag=cms.InputTag('slimmedMETs'),
+
+    # selection and similar
+    isElectron=cms.bool(True),
+    #
+    prefix=cms.string('TopPairElectronPlusJetsSelection.'),
+    suffix=cms.string(''),
+)

--- a/src/BristolNTuple_GlobalEventVars.cc
+++ b/src/BristolNTuple_GlobalEventVars.cc
@@ -1,3 +1,8 @@
+/**
+ *
+ * @deprecated
+ */
+
 #include "BristolAnalysis/NTupleTools/interface/BristolNTuple_GlobalEventVars.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"


### PR DESCRIPTION
As part of the efforts to replace AS, I've added the global variabels to the ntuples.
This is done per 'object family' such that we have the variables per selection.

Of course, the global vars are only valid if you also check if the event passes the appropriate selection (e.g. HT is well defined for 1 jet).

Test ntuple can be found on soolin in `/storage/phxlk/eventUserData.root`