### PR TITLE
Fix for issue #289

### DIFF
--- a/python/ntp/commands/run/__init__.py
+++ b/python/ntp/commands/run/__init__.py
@@ -23,12 +23,12 @@ CONDOR_ROOT = os.path.join(WORKSPACE, 'condor')
 
 class Command(C):
     REQUIRE_GRID_CERT = True
+    _have_fresh_tar_files = False
 
     def __init__(self, path=__file__, doc=__doc__):
         super(Command, self).__init__(path, doc)
 
         # condor specific
-        self.__have_fresh_tar_files = False
         self.__input_files = []
         self.__job_log_dir = ''
         self.__job_dir = ''
@@ -62,19 +62,19 @@ class Command(C):
             results.append('"{0}"'.format(f))
         return ',\n'.join(results)
 
-    def __create_tar_file(self, args, variables):
+    def _create_tar_file(self, args, variables):
         from ntp.commands.create.tarball import Command as TarCommand
         no_operation = 'noop' in self.__variables and self.__variables['noop']
         if no_operation and TarCommand.tarballs_exist():
             self.__input_files.extend(TarCommand.get_existing_files())
             return
-        if self.__have_fresh_tar_files:
+        if Command._have_fresh_tar_files:
             return
         c = TarCommand()
         c.run(args, variables)
         self.__text += c.__text
         self.__input_files.extend(c.get_tar_files())
-        self.__have_fresh_tar_files = True
+        Command._have_fresh_tar_files = True
 
     def __get_job_dir(self, category, name):
         out_dir = os.path.join(CONDOR_ROOT, category, name)

--- a/python/ntp/commands/run/analysis/DICE.py
+++ b/python/ntp/commands/run/analysis/DICE.py
@@ -72,7 +72,7 @@ class Command(C):
         mode = self.__variables['mode']
 
         # create tarball
-        self.__create_tar_file(args, variables)
+        self._create_tar_file(args, variables)
 
         self.__run_dataset(dataset, mode)
         # to check status:

--- a/python/ntp/commands/run/condor/__init__.py
+++ b/python/ntp/commands/run/condor/__init__.py
@@ -136,7 +136,7 @@ class Command(C):
         chosen_dataset = self.__variables['dataset']
 
         # create tarball
-        self.__create_tar_file(args, variables)
+        self._create_tar_file(args, variables)
 
         datasets = [chosen_dataset]
         if chosen_dataset.lower() == 'all':

--- a/python/ntp/commands/run/dps/DICE.py
+++ b/python/ntp/commands/run/dps/DICE.py
@@ -67,7 +67,7 @@ class Command(C):
             self.__phase_space = 'FullPS'
 
         # create tarball
-        self.__create_tar_file(args, variables)
+        self._create_tar_file(args, variables)
 
         self.__run_variable(variable)
         # to check status:

--- a/python/ntp/commands/run/ntuple/DICE.py
+++ b/python/ntp/commands/run/ntuple/DICE.py
@@ -61,7 +61,7 @@ class Command(ParentCommand):
         dataset = self.__variables['dataset']
 
         # create tarball
-        self.__create_tar_file(args, variables)
+        self._create_tar_file(args, variables)
 
         self.__run(campaign, dataset)
         # to check status:

--- a/python/ntp/commands/run/test/test_run.py
+++ b/python/ntp/commands/run/test/test_run.py
@@ -1,0 +1,49 @@
+'''
+Created on 10 Feb 2017
+
+@author: phxlk
+'''
+import unittest
+import os
+
+from ntp.commands.create.tarball import Command as TarCommand
+from ntp.commands.run import Command as RunCommand
+
+
+class Test(unittest.TestCase):
+
+
+    def setUp(self):
+        existing_files = TarCommand.get_existing_files()
+        for f in existing_files:
+            os.remove(f)
+
+
+    def tearDown(self):
+        pass
+
+
+    def testCreateTar(self):
+        c1 = RunCommand()
+        c1._create_tar_file([], {})
+        existing_files = TarCommand.get_existing_files()
+        self.assertTrue(len(existing_files) > 0)
+        
+        if not existing_files:
+            return
+        
+        mtime1 = os.path.getmtime(existing_files[0])
+        
+        c2 = RunCommand()
+        # this should not create a second tar file
+        # since a "fresh" one exists
+        c2._create_tar_file([], {})
+        existing_files = TarCommand.get_existing_files()
+        mtime2 = os.path.getmtime(existing_files[0])
+        self.assertEqual(mtime1, mtime2)
+            
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testCreateTar']
+    unittest.main()


### PR DESCRIPTION
 - adds test for the bug
 - renamed `__create_tar_file` to `_create_tar_file` so it can be accessed in the test
 - fixed the issue by making `_have_fresh_tar_files` into a class variable (instead of instance)

In this implementation the tar files will be created once per command execution, e.g.
 - `ntp run datasets=all` will create the tar files once
 - running `ntp run datasets=all` right after that will create the tar files again.