### PR TITLE
Remove egmID merge, run regression form online db, update version

### DIFF
--- a/python/Electron_Setup_cff.py
+++ b/python/Electron_Setup_cff.py
@@ -14,12 +14,12 @@ def setup_electrons(process, cms, options):
 	# process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
 
 	# Apply the regression from a remote database
-	# from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
-	# process = regressionWeights(process)
-	# process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
+	from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
+	process = regressionWeights(process)
+	process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
 
 	# Apply from GT
-	process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
+	# process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
 
 	process.electronRegression = cms.Sequence(process.regressionApplication)
 

--- a/python/crab/base.py
+++ b/python/crab/base.py
@@ -15,7 +15,7 @@ if not 'HEP_PROJECT_ROOT' in os.environ:
     sys.exit(-1)
 
 # this is the NTupleVersion!
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 NTPROOT = os.environ['HEP_PROJECT_ROOT']
 WORKSPACE = os.path.join(NTPROOT, 'workspace')
 CRAB_WS = os.path.join(WORKSPACE, 'crab')

--- a/setup.json
+++ b/setup.json
@@ -39,11 +39,6 @@
 			"destination": "TopQuarkAnalysis/TopHitFit",
 			"provider": "git"
 		},{
-			"name": "egammaID",
-			"source": "ikrav:egm_id_80X_v2",
-			"destination": "",
-			"provider": "git-cms-merge-topic"
-		},{
 			"name": "recoMET",
 			"source": "cms-met:METRecipe_8020",
 			"destination": "",


### PR DESCRIPTION
NTP compiles correctly for me, with these changes. (Though non have anything to do with the not finding miniAODToNTuple bug.) 
Removing egammaID reduces amount of checked out packages reducing compile time.
Running regression from GT was broken, reverted to running from online database.
updated ntp version.