### PR TITLE
Pseudolepton fixes

### DIFF
--- a/python/BristolNTuple_PseudoTop_cfi.py
+++ b/python/BristolNTuple_PseudoTop_cfi.py
@@ -13,7 +13,7 @@ nTuplePseudoTopLeptons = cms.EDProducer("BristolNTuple_GenJets",
     InputTag = cms.InputTag('pseudoTop','leptons','Ntuples'),
     Prefix = cms.string('PseudoTopLeptons.'),
     Suffix = cms.string(''),
-    minPt = cms.double(20),
+    minPt = cms.double(15),
     maxAbsoluteEta = cms.double(999),
     MaxSize = cms.uint32(99)
 )

--- a/python/crab/base.py
+++ b/python/crab/base.py
@@ -15,7 +15,7 @@ if not 'HEP_PROJECT_ROOT' in os.environ:
     sys.exit(-1)
 
 # this is the NTupleVersion!
-__version__ = '1.0.12'
+__version__ = '1.0.14'
 NTPROOT = os.environ['HEP_PROJECT_ROOT']
 WORKSPACE = os.path.join(NTPROOT, 'workspace')
 CRAB_WS = os.path.join(WORKSPACE, 'crab')

--- a/python/pseudoTopConfig_cff.py
+++ b/python/pseudoTopConfig_cff.py
@@ -7,6 +7,8 @@ def setupPseudoTop( process, cms ):
 
 	process.load( "TopQuarkAnalysis.TopEventProducers.producers.pseudoTop_cfi" )
 	process.pseudoTop.minJetPt = cms.double(20)
+	process.pseudoTop.maxLeptonEta = cms.double(2.4)
+	process.pseudoTop.runTopReconstruction = cms.bool(False)
 
 	process.load('TopQuarkAnalysis.BFragmentationAnalyzer.bfragWgtProducer_cfi')
 	process.makePseudoTop = cms.Sequence( process.mergedGenParticles * process.genParticles2HepMC * process.pseudoTop * process.bfragWgtProducer )


### PR DESCRIPTION
Fixes to pseudo lepton definition.  Results in perfect agreement between analysis and rivet plugin.

- Store pseudo leptons down to 15 GeV in ntuples
We used to produce leptons down to 15 GeV, but only store above 20GeV, so veto lepton selection was buggy

- Only produce leptons up to |eta| = 2.4
We used to produce leptons up to 2.5 (default configuration from TQAF), which didn't affect veto selection, but could affect particles used in the jet clustering.

- Update ntuple version to 1.0.14